### PR TITLE
Enchantable weapons with touch spells

### DIFF
--- a/src/main/java/com/teamwizardry/wizardry/api/Constants.java
+++ b/src/main/java/com/teamwizardry/wizardry/api/Constants.java
@@ -57,7 +57,10 @@ public class Constants {
 	}
 
 	public static class NBT {
+		public static final String VANILLA_PREFIX = "wizardry_";	// To avoid naming collisions
+		
 		public static final String SPELL = "spellData";
+		public static final String PEARL_TYPE = "type";
 		public static final String TAG_OVERLAY = "overlay";
 		public static final String FAIRY_INSIDE = "fairy_inside";
 		public static final String FAIRY_COLOR = "fairy_color";

--- a/src/main/java/com/teamwizardry/wizardry/api/item/IInfusable.java
+++ b/src/main/java/com/teamwizardry/wizardry/api/item/IInfusable.java
@@ -1,5 +1,7 @@
 package com.teamwizardry.wizardry.api.item;
 
+import com.teamwizardry.wizardry.api.capability.IWizardryCapability;
+
 import net.minecraft.item.ItemStack;
 
 /**
@@ -13,4 +15,11 @@ public interface IInfusable {
 			return stack.getTagCompound().hasKey("type") ? EnumPearlType.valueOf(stack.getTagCompound().getString("type").toUpperCase()) : EnumPearlType.MUNDANE;
 		else return EnumPearlType.MUNDANE;
 	}
+	
+	default boolean canBeInfused(ItemStack stack) {
+		if( getType(stack) == EnumPearlType.MUNDANE )
+			return true;
+		return false;
+	}
+	
 }

--- a/src/main/java/com/teamwizardry/wizardry/api/spell/SpellUtils.java
+++ b/src/main/java/com/teamwizardry/wizardry/api/spell/SpellUtils.java
@@ -55,13 +55,33 @@ public class SpellUtils {
 	}
 
 	public static void runSpell(@Nonnull ItemStack spellHolder, @Nonnull SpellData data) {
+		runSpell(spellHolder, data);
+	}
+	
+	public static void runSpell(@Nonnull ItemStack spellHolder, String prefix, @Nonnull SpellData data) {
+		if( prefix == null )
+			prefix = "";
+		
+		NBTTagList list = ItemNBTHelper.getList(spellHolder, prefix + Constants.NBT.SPELL, net.minecraftforge.common.util.Constants.NBT.TAG_COMPOUND);
+		if( list == null )
+			return;
+		
+		runSpell(list, data);
+	}
+	
+	public static void runSpell(@Nonnull NBTTagList spellList, @Nonnull SpellData data) {
+		runSpell(getSpellChains(spellList), data);
+	}
+	
+	public static void runSpell(@Nonnull List<SpellRing> spellList, @Nonnull SpellData data) {
 		if (data.world.isRemote) return;
+		if( spellList == null || spellList.isEmpty() ) return;
 
 		Entity caster = data.getData(SpellData.DefaultKeys.CASTER);
 		if (caster != null && caster instanceof EntityLivingBase && BaublesSupport.getItem((EntityLivingBase) caster, ModItems.CREATIVE_HALO, ModItems.FAKE_HALO, ModItems.REAL_HALO).isEmpty())
 			return;
 
-		for (SpellRing spellRing : getSpellChains(spellHolder)) {
+		for (SpellRing spellRing : spellList) {
 			spellRing.runSpellRing(data);
 		}
 	}
@@ -91,6 +111,8 @@ public class SpellUtils {
 	 */
 	public static List<SpellRing> getSpellChains(@Nonnull NBTTagList list) {
 		ArrayList<SpellRing> rings = new ArrayList<>();
+		if( list == null || list.hasNoTags() )
+			return rings;
 		for (int i = 0; i < list.tagCount(); i++) {
 			NBTTagCompound compound = list.getCompoundTagAt(i);
 			SpellRing ring = SpellRing.deserializeRing(compound);

--- a/src/main/java/com/teamwizardry/wizardry/common/block/BlockCraftingPlate.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/block/BlockCraftingPlate.java
@@ -18,6 +18,8 @@ import com.teamwizardry.wizardry.common.tile.TileCraftingPlate;
 import com.teamwizardry.wizardry.init.ModItems;
 import com.teamwizardry.wizardry.init.ModSounds;
 import com.teamwizardry.wizardry.init.ModStructures;
+import com.teamwizardry.wizardry.utils.InfusionHelper;
+
 import net.minecraft.block.SoundType;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
@@ -110,11 +112,14 @@ public class BlockCraftingPlate extends BlockModContainer implements IStructure 
 				} else {
 					ItemStack stack = heldItem.copy();
 					stack.setCount(1);
-					heldItem.shrink(1);
 
-					if (!plate.isInventoryEmpty() && stack.getItem() instanceof IInfusable) {
+					IInfusable infusable = InfusionHelper.getInfusable(stack.getItem());
+					boolean canBeInfused = infusable != null && infusable.canBeInfused(stack);
+
+					boolean itemConsumed = true;
+					if (!plate.isInventoryEmpty() && canBeInfused) {
 						plate.inputPearl.getHandler().setStackInSlot(0, stack);
-					} else if (!(stack.getItem() instanceof IInfusable)) {
+					} else if (!canBeInfused) {
 						for (int i = 0; i < plate.realInventory.getHandler().getSlots(); i++) {
 							if (plate.realInventory.getHandler().getStackInSlot(i).isEmpty()) {
 								plate.realInventory.getHandler().setStackInSlot(i, stack);
@@ -131,9 +136,14 @@ public class BlockCraftingPlate extends BlockModContainer implements IStructure 
 							}
 						}
 					}
+					else
+						itemConsumed = false;
 
-					playerIn.openContainer.detectAndSendChanges();
-					worldIn.notifyBlockUpdate(pos, state, state, 3);
+					if( itemConsumed ) {
+						heldItem.shrink(1);
+						playerIn.openContainer.detectAndSendChanges();
+						worldIn.notifyBlockUpdate(pos, state, state, 3);
+					}
 					return true;
 				}
 			} else {

--- a/src/main/java/com/teamwizardry/wizardry/common/core/InfusionEventHandler.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/core/InfusionEventHandler.java
@@ -1,0 +1,192 @@
+package com.teamwizardry.wizardry.common.core;
+
+import java.util.Map;
+
+import com.teamwizardry.librarianlib.features.helpers.ItemNBTHelper;
+import com.teamwizardry.wizardry.api.Constants;
+import com.teamwizardry.wizardry.init.ModEnchantments;
+import com.teamwizardry.wizardry.utils.InfusedItemStackNBTData;
+
+import net.minecraft.enchantment.Enchantment;
+import net.minecraft.enchantment.EnchantmentHelper;
+import net.minecraft.init.Items;
+import net.minecraft.item.ItemEnchantedBook;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTTagList;
+import net.minecraftforge.event.AnvilUpdateEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+public class InfusionEventHandler {
+	
+	// TODO: Add to com.teamwizardry.wizardry.common.core.EventHandler.EventHandler() instead
+	
+	@SubscribeEvent
+	public void onAnvilUpdateEvent( AnvilUpdateEvent event ) {
+		ItemStack itemToEnchant = event.getLeft();
+		ItemStack book = event.getRight();
+		if( book.getItem() != Items.ENCHANTED_BOOK )
+			return;
+
+		// Check if it is a correctly infused book
+		Map<Enchantment, Integer> enchantments = EnchantmentHelper.getEnchantments(book);
+		if( enchantments.get(ModEnchantments.enchantmentInfusion) == null )
+			return;
+
+//		NBTTagList spellData = ItemNBTHelper.getList(book, Constants.NBT.VANILLA_PREFIX + Constants.NBT.SPELL, net.minecraftforge.common.util.Constants.NBT.TAG_COMPOUND);
+//		if( spellData == null )
+//			return;
+		
+//		String type = ItemNBTHelper.getString(book, Constants.NBT.VANILLA_PREFIX + Constants.NBT.PEARL_TYPE, "");
+//		if( type.isEmpty() )
+//			return;
+		
+		InfusedItemStackNBTData data =
+				new InfusedItemStackNBTData(Constants.NBT.VANILLA_PREFIX)
+					.initByStack(book);
+		if( !data.isComplete() )
+			return;
+		
+		// Now try to apply effects by vanilla mechanics
+		if( !applyVanillaEnchantmentsFromBook(event, itemToEnchant, book, enchantments) )
+			return;
+
+		// Copy all wizardry data
+//		float rand = ItemNBTHelper.getFloat(book, Constants.NBT.VANILLA_PREFIX + Constants.NBT.RAND, 0);
+		ItemStack output = event.getOutput();
+		data.assignToStack(output);
+//		ItemNBTHelper.setString(output, Constants.NBT.VANILLA_PREFIX + Constants.NBT.PEARL_TYPE, type);
+//		ItemNBTHelper.setFloat(output, Constants.NBT.VANILLA_PREFIX + Constants.NBT.RAND, rand);
+//		ItemNBTHelper.setList(output, Constants.NBT.VANILLA_PREFIX + Constants.NBT.SPELL, spellData);
+		
+		// TODO: Merge effects if two infused books are combined
+	}
+	
+	private static boolean applyVanillaEnchantmentsFromBook(AnvilUpdateEvent event, ItemStack itemToEnchant, ItemStack book, Map<Enchantment, Integer> newEnchantments) {
+		// NOTE: Copied and adapted from net.minecraft.inventory.ContainerRepair.updateRepairOutput() 
+		
+		Map<Enchantment, Integer> curEnchantments = EnchantmentHelper.getEnchantments(itemToEnchant);
+		int cost = 0;
+		boolean flag2 = false;
+        boolean flag3 = false;
+
+        for (Enchantment enchantment1 : newEnchantments.keySet())
+        {
+            if (enchantment1 != null)
+            {
+                int i2 = curEnchantments.containsKey(enchantment1) ? ((Integer)curEnchantments.get(enchantment1)).intValue() : 0;
+                int j2 = ((Integer)newEnchantments.get(enchantment1)).intValue();
+                j2 = i2 == j2 ? j2 + 1 : Math.max(j2, i2);
+                boolean flag1 = enchantment1.canApply(itemToEnchant);
+
+                if (/*this.player.capabilities.isCreativeMode || */itemToEnchant.getItem() == Items.ENCHANTED_BOOK)
+                {
+                    flag1 = true;
+                }
+
+                for (Enchantment enchantment : curEnchantments.keySet())
+                {
+                    if (enchantment != enchantment1 && !enchantment1.isCompatibleWith(enchantment))
+                    {
+                        flag1 = false;
+                        ++cost;
+                    }
+                }
+
+                if (!flag1)
+                {
+                    flag3 = true;
+                }
+                else
+                {
+                    flag2 = true;
+
+                    if (j2 > enchantment1.getMaxLevel())
+                    {
+                        j2 = enchantment1.getMaxLevel();
+                    }
+
+                    curEnchantments.put(enchantment1, Integer.valueOf(j2));
+                    int k3 = 0;
+
+                    switch (enchantment1.getRarity())
+                    {
+                        case COMMON:
+                            k3 = 1;
+                            break;
+                        case UNCOMMON:
+                            k3 = 2;
+                            break;
+                        case RARE:
+                            k3 = 4;
+                            break;
+                        case VERY_RARE:
+                            k3 = 8;
+                    }
+
+//                    if (flag)
+                    {
+                        k3 = Math.max(1, k3 / 2);
+                    }
+
+                    cost += k3 * j2;
+
+                    if (itemToEnchant.getCount() > 1)
+                    {
+                    	cost = 40;
+                    }
+                }
+            }
+        }
+
+        if (flag3 && !flag2)
+        {
+//            this.outputSlot.setInventorySlotContents(0, ItemStack.EMPTY);
+//            this.maximumCost = 0;
+        	event.setCost(0);
+            return false;
+        }
+        
+        ItemStack output = itemToEnchant.copy();
+        
+        if (!itemToEnchant.getItem().isBookEnchantable(itemToEnchant, book)) {
+//        	output = ItemStack.EMPTY;
+        	return false;
+        }
+
+        if (cost <= 0)
+        {
+//            output = ItemStack.EMPTY;
+        	return false;
+        }
+
+        if (event.getCost() >= 40 /*&& !this.player.capabilities.isCreativeMode */ )
+        {
+//        	output = ItemStack.EMPTY;
+        	return false;
+        }
+
+//        if (!output.isEmpty())
+//        {
+            int k2 = output.getRepairCost();
+
+//            if (!book.isEmpty() && k2 < book.getRepairCost())
+//            {
+//                k2 = book.getRepairCost();
+//            }
+
+//            if (k != i || k == 0)
+//            {
+                k2 = k2 * 2 + 1;
+//            }
+
+            output.setRepairCost(k2);
+            EnchantmentHelper.setEnchantments(curEnchantments, output);
+//        }
+//        else
+
+        event.setCost(itemToEnchant.getRepairCost() + cost);
+        event.setOutput(output);
+        return true;
+	}
+}

--- a/src/main/java/com/teamwizardry/wizardry/common/enchantment/EnchantmentInfusion.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/enchantment/EnchantmentInfusion.java
@@ -1,0 +1,33 @@
+package com.teamwizardry.wizardry.common.enchantment;
+
+import com.teamwizardry.librarianlib.features.base.EnchantmentMod;
+
+import net.minecraft.enchantment.Enchantment;
+import net.minecraft.enchantment.EnumEnchantmentType;
+import net.minecraft.enchantment.Enchantment.Rarity;
+import net.minecraft.inventory.EntityEquipmentSlot;
+import net.minecraft.item.ItemStack;
+
+public class EnchantmentInfusion extends EnchantmentMod {
+
+	public EnchantmentInfusion() {
+		super("infusion", Rarity.COMMON, EnumEnchantmentType.ALL, EntityEquipmentSlot.MAINHAND);
+	}
+	
+	@Override
+    public boolean canApplyAtEnchantingTable(ItemStack stack)
+    {
+        return false;
+    }
+    
+	@Override
+    public boolean canApply(ItemStack stack)
+    {
+        return true;
+    }
+	
+	@Override
+	public String getTranslatedName(int level) {
+		return super.getTranslatedName(level);
+	}
+}

--- a/src/main/java/com/teamwizardry/wizardry/common/item/ItemStaff.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/item/ItemStaff.java
@@ -14,6 +14,8 @@ import com.teamwizardry.wizardry.api.spell.SpellRing;
 import com.teamwizardry.wizardry.api.spell.SpellUtils;
 import com.teamwizardry.wizardry.common.module.shapes.ModuleShapeTouch;
 import com.teamwizardry.wizardry.init.ModItems;
+import com.teamwizardry.wizardry.utils.SpellCasting;
+
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.util.ITooltipFlag;
@@ -52,28 +54,8 @@ public class ItemStaff extends ItemMod implements INacreProduct.INacreDecayProdu
 
 	@Override
 	public boolean itemInteractionForEntity(ItemStack stack, EntityPlayer playerIn, EntityLivingBase target, EnumHand hand) {
-		if (isCoolingDown(stack)) return false;
-
-		if (BaublesSupport.getItem(playerIn, ModItems.CREATIVE_HALO, ModItems.FAKE_HALO, ModItems.REAL_HALO).isEmpty())
-			return false;
-
-		boolean touch = false;
-		for (SpellRing ring : SpellUtils.getSpellChains(stack)) {
-			if (ring.getModule() instanceof ModuleShapeTouch) {
-				touch = true;
-				break;
-			}
-		}
-
-		if (!touch) return false;
-
-		SpellData spell = new SpellData(playerIn.world);
-		spell.processEntity(playerIn, true);
-		spell.processEntity(target, false);
-		SpellUtils.runSpell(stack, spell);
-
-		setCooldown(playerIn.world, playerIn, hand, stack, spell);
-		return true;
+		List<SpellRing> spellList = SpellUtils.getSpellChains(stack);
+		return SpellCasting.touchInteract(stack, spellList, playerIn, target, hand);
 	}
 
 	@Nonnull

--- a/src/main/java/com/teamwizardry/wizardry/common/tile/TileCraftingPlate.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/tile/TileCraftingPlate.java
@@ -203,7 +203,7 @@ public class TileCraftingPlate extends TileManaInteractor {
 				ItemStack inputStack = inputPearl.getHandler().getStackInSlot(0);
 				Item inputItem = inputStack.getItem();
 				if( inputItem == Items.BOOK || inputItem == Items.ENCHANTED_BOOK ) {
-					prefix = Constants.NBT.VANILLA_PREFIX;	// To avoid collisions in a vanilla namespace. 
+					prefix = Constants.NBT.VANILLA_PREFIX;	// To avoid collisions in a vanilla namespace with other mods. 
 					
 					if( inputItem != Items.ENCHANTED_BOOK )
 						infusedProduct = new ItemStack(Items.ENCHANTED_BOOK);
@@ -225,12 +225,11 @@ public class TileCraftingPlate extends TileManaInteractor {
 				inputPearl.getHandler().setStackInSlot(0, ItemStack.EMPTY);
 				outputPearl.getHandler().setStackInSlot(0, infusedProduct);
 
+				// NOTE: Change crafting.infusion.InfusionEventHandler.onAnvilUpdateEvent() if changed nbt structure!
 				//Color lastColor = SpellUtils.getAverageSpellColor(builder.getSpell());
 				//float[] hsv = ColorUtils.getHSVFromColor(lastColor);
 				//ItemNBTHelper.setFloat(infusedPearl, "hue", hsv[0]);
 				//ItemNBTHelper.setFloat(infusedPearl, "saturation", hsv[1]);
-//				ItemNBTHelper.setFloat(infusedProduct, prefix + Constants.NBT.RAND, world.rand.nextFloat());
-//				ItemNBTHelper.setString(infusedProduct, prefix + Constants.NBT.PEARL_TYPE, EnumPearlType.INFUSED.toString());
 
 				// Process spellData multipliers based on nacre quality
 				double pearlMultiplier = 1;
@@ -246,14 +245,7 @@ public class TileCraftingPlate extends TileManaInteractor {
 				}
 				
 				SpellBuilder builder = new SpellBuilder(stacks, pearlMultiplier);
-
-//				NBTTagList list = new NBTTagList();
-//				for (SpellRing spellRing : builder.getSpell()) {
-//					list.appendTag(spellRing.serializeNBT());
-//				}
-//				ItemNBTHelper.setList(infusedProduct, prefix + Constants.NBT.SPELL, list);
 				
-				// NOTE: Change crafting.infusion.InfusionEventHandler.onAnvilUpdateEvent() if changed nbt structure!
 				new InfusedItemStackNBTData(prefix)
 					.setRand(world.rand.nextFloat())
 					.setSpellList(builder)

--- a/src/main/java/com/teamwizardry/wizardry/init/ModCapabilities.java
+++ b/src/main/java/com/teamwizardry/wizardry/init/ModCapabilities.java
@@ -1,12 +1,16 @@
 package com.teamwizardry.wizardry.init;
 
 import com.teamwizardry.wizardry.Wizardry;
+import com.teamwizardry.wizardry.api.capability.CustomWizardryCapability;
 import com.teamwizardry.wizardry.api.capability.DefaultWizardryCapability;
 import com.teamwizardry.wizardry.api.capability.IWizardryCapability;
 import com.teamwizardry.wizardry.api.capability.WizardryCapabilityProvider;
 import com.teamwizardry.wizardry.api.capability.WizardryCapabilityStorage;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.init.Items;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.common.capabilities.CapabilityManager;
 import net.minecraftforge.event.AttachCapabilitiesEvent;
@@ -27,6 +31,19 @@ public class ModCapabilities {
 		if (e.getObject() instanceof EntityPlayer) {
 			WizardryCapabilityProvider cap = new WizardryCapabilityProvider(new DefaultWizardryCapability());
 			e.addCapability(new ResourceLocation(Wizardry.MODID, "capabilities"), cap);
+		}
+	}
+	
+	@SubscribeEvent
+	public void onAddCapabilitiesOnVanilla(AttachCapabilitiesEvent<ItemStack> event) {
+		ItemStack itemStack = event.getObject();
+		if( itemStack.getItem() == Items.BOOK || itemStack.getItem() == Items.ENCHANTED_BOOK ) {
+			if( itemStack.hasCapability(WizardryCapabilityProvider.wizardryCapability, null) )
+				return;
+			event.addCapability(
+					new ResourceLocation(Wizardry.MODID, "wizcaps"),
+					new WizardryCapabilityProvider(
+							new CustomWizardryCapability(300, 300, 0, 0)));
 		}
 	}
 }

--- a/src/main/java/com/teamwizardry/wizardry/init/ModEnchantments.java
+++ b/src/main/java/com/teamwizardry/wizardry/init/ModEnchantments.java
@@ -1,0 +1,11 @@
+package com.teamwizardry.wizardry.init;
+
+import com.teamwizardry.wizardry.common.enchantment.EnchantmentInfusion;
+
+public class ModEnchantments {
+	public static EnchantmentInfusion enchantmentInfusion;
+	
+	public static void init() { 
+		enchantmentInfusion = new EnchantmentInfusion();
+	}
+}

--- a/src/main/java/com/teamwizardry/wizardry/init/irecipies/RecipePearl.java
+++ b/src/main/java/com/teamwizardry/wizardry/init/irecipies/RecipePearl.java
@@ -51,7 +51,7 @@ public class RecipePearl extends IForgeRegistryEntry.Impl<IRecipe> implements IR
 				if (stack.getItemDamage() == 0)
 					baseItem = stack;
 			}
-			if (stack.getItem() instanceof IInfusable)
+			if (stack.getItem() instanceof ItemNacrePearl)
 				pearl = stack;
 		}
 

--- a/src/main/java/com/teamwizardry/wizardry/proxy/CommonProxy.java
+++ b/src/main/java/com/teamwizardry/wizardry/proxy/CommonProxy.java
@@ -9,6 +9,7 @@ import com.teamwizardry.wizardry.api.spell.module.ModuleRegistry;
 import com.teamwizardry.wizardry.client.gui.GuiHandler;
 import com.teamwizardry.wizardry.common.advancement.AchievementEvents;
 import com.teamwizardry.wizardry.common.core.EventHandler;
+import com.teamwizardry.wizardry.common.core.InfusionEventHandler;
 import com.teamwizardry.wizardry.common.core.SpellTicker;
 import com.teamwizardry.wizardry.common.entity.angel.zachriel.nemez.NemezEventHandler;
 import com.teamwizardry.wizardry.common.module.effects.ModuleEffectLeap;
@@ -58,6 +59,7 @@ public class CommonProxy {
 		ModPotions.init();
 		ModEntities.init();
 		ModCapabilities.preInit();
+		ModEnchantments.init();
 
 		NetworkRegistry.INSTANCE.registerGuiHandler(Wizardry.instance, new GuiHandler());
 
@@ -67,6 +69,7 @@ public class CommonProxy {
 		MinecraftForge.EVENT_BUS.register(ArenaManager.INSTANCE);
 		MinecraftForge.EVENT_BUS.register(new WorldProviderUnderWorld());
 		MinecraftForge.EVENT_BUS.register(new EventHandler());
+		MinecraftForge.EVENT_BUS.register(new InfusionEventHandler());
 		MinecraftForge.EVENT_BUS.register(new AchievementEvents());
 		MinecraftForge.EVENT_BUS.register(new ModCapabilities());
 		MinecraftForge.EVENT_BUS.register(new ModuleEffectTimeSlow());

--- a/src/main/java/com/teamwizardry/wizardry/utils/InfusedItemStackNBTData.java
+++ b/src/main/java/com/teamwizardry/wizardry/utils/InfusedItemStackNBTData.java
@@ -1,0 +1,79 @@
+package com.teamwizardry.wizardry.utils;
+
+import com.teamwizardry.librarianlib.features.helpers.ItemNBTHelper;
+import com.teamwizardry.wizardry.api.Constants;
+import com.teamwizardry.wizardry.api.item.EnumPearlType;
+import com.teamwizardry.wizardry.api.spell.SpellBuilder;
+import com.teamwizardry.wizardry.api.spell.SpellRing;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagList;
+
+public class InfusedItemStackNBTData {
+	private float rand;
+	private NBTTagList spellList;
+	private String pearlType; 
+	private final String prefix;
+	
+	public InfusedItemStackNBTData(String prefix) {
+		this.prefix = prefix;
+	}
+	
+	public InfusedItemStackNBTData initByStack(ItemStack stack) {
+		spellList = ItemNBTHelper.getList(stack, prefix + Constants.NBT.SPELL, net.minecraftforge.common.util.Constants.NBT.TAG_COMPOUND);
+		pearlType = ItemNBTHelper.getString(stack, prefix + Constants.NBT.PEARL_TYPE, "");
+		if( pearlType.isEmpty() )
+			pearlType = null;
+		rand = ItemNBTHelper.getFloat(stack, prefix + Constants.NBT.RAND, 0);
+		return this;
+	}
+	
+	public InfusedItemStackNBTData setRand(float rand) {
+		this.rand = rand;
+		return this;
+	}
+	
+	public float getRand() {
+		return this.rand;
+	}
+	
+	public InfusedItemStackNBTData setSpellList(NBTTagList spellList) {
+		this.spellList = spellList;
+		return this;
+	}
+
+	public InfusedItemStackNBTData setSpellList(SpellBuilder builder) {
+		NBTTagList list = new NBTTagList();
+		for (SpellRing spellRing : builder.getSpell()) {
+			list.appendTag(spellRing.serializeNBT());
+		}
+		this.spellList = list;
+		return this;
+	}
+	
+	public NBTTagList getSpellList() {
+		return this.spellList;
+	}
+	
+	public InfusedItemStackNBTData setPearlType(EnumPearlType pearlType) {
+		this.pearlType = pearlType.toString();
+		return this;
+	}
+	
+	public String getPearlType() {
+		return this.pearlType;
+	}
+	
+	public boolean isComplete() {
+		return spellList != null && pearlType != null;
+	}
+	
+	public void assignToStack(ItemStack target) {
+		if( !isComplete() )
+			throw new IllegalStateException("Can't assign incomplete state!");
+		
+		ItemNBTHelper.setFloat(target, prefix + Constants.NBT.RAND, rand);
+		ItemNBTHelper.setString(target, prefix + Constants.NBT.PEARL_TYPE, pearlType);
+		ItemNBTHelper.setList(target, prefix + Constants.NBT.SPELL, spellList);
+	}
+}

--- a/src/main/java/com/teamwizardry/wizardry/utils/InfusionHelper.java
+++ b/src/main/java/com/teamwizardry/wizardry/utils/InfusionHelper.java
@@ -1,0 +1,36 @@
+package com.teamwizardry.wizardry.utils;
+
+import com.teamwizardry.wizardry.api.item.EnumPearlType;
+import com.teamwizardry.wizardry.api.item.IInfusable;
+
+import net.minecraft.init.Items;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+
+public class InfusionHelper {
+	
+	public static IInfusable getInfusable(final Item item) {
+		if( item instanceof IInfusable )
+			return (IInfusable)item;
+		
+		if( item == Items.BOOK || item == Items.ENCHANTED_BOOK ) {
+			return new IInfusable() {
+				@Override
+				public EnumPearlType getType(ItemStack stack) {
+					return ( item == Items.ENCHANTED_BOOK ) ? EnumPearlType.INFUSED : EnumPearlType.MUNDANE;
+				}
+				
+/*				@Override
+				public IWizardryCapability getOverridenWizardCapability(ItemStack stack, IWizardryCapability defaultCapability) {
+					// stack.s CAP_ON_VANILLA
+					NBTTagCompound compound = ItemNBTHelper.getCompound(stack, Constants.NBT.CAP_ON_VANILLA);
+					 
+				} */
+			};
+		}
+		
+		return null;
+	}
+	
+
+}

--- a/src/main/java/com/teamwizardry/wizardry/utils/SpellCasting.java
+++ b/src/main/java/com/teamwizardry/wizardry/utils/SpellCasting.java
@@ -1,0 +1,49 @@
+package com.teamwizardry.wizardry.utils;
+
+import java.util.List;
+
+import com.teamwizardry.wizardry.api.item.BaublesSupport;
+import com.teamwizardry.wizardry.api.item.ICooldown;
+import com.teamwizardry.wizardry.api.spell.SpellData;
+import com.teamwizardry.wizardry.api.spell.SpellRing;
+import com.teamwizardry.wizardry.api.spell.SpellUtils;
+import com.teamwizardry.wizardry.common.module.shapes.ModuleShapeTouch;
+import com.teamwizardry.wizardry.init.ModItems;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumHand;
+
+public class SpellCasting {
+	
+	public static boolean touchInteract(ItemStack stack, List<SpellRing> spells, EntityPlayer player, Entity target, EnumHand hand) {
+		Item item = stack.getItem();
+		ICooldown cooldown = (item instanceof ICooldown)? (ICooldown)item : null; 
+		if (cooldown != null && cooldown.isCoolingDown(stack))
+			return false;
+
+		if (BaublesSupport.getItem(player, ModItems.CREATIVE_HALO, ModItems.FAKE_HALO, ModItems.REAL_HALO).isEmpty())
+			return false;
+
+		boolean touch = false;
+		for (SpellRing ring : spells) {
+			if (ring.getModule() instanceof ModuleShapeTouch) {
+				touch = true;
+				break;
+			}
+		}
+
+		if (!touch) return false;
+
+		SpellData spell = new SpellData(player.world);
+		spell.processEntity(player, true);
+		spell.processEntity(target, false);
+		SpellUtils.runSpell(spells, spell);
+
+		if (cooldown != null )
+			cooldown.setCooldown(player.world, player, hand, stack, spell);
+		return true;
+	}
+}

--- a/src/main/resources/assets/wizardry/lang/en_us.lang
+++ b/src/main/resources/assets/wizardry/lang/en_us.lang
@@ -116,6 +116,8 @@ advancement.wizardry.devildust.desc=Melt book in fire to make Devil Dust
 advancement.wizardry.crunch=§oCRUNCH.§a
 advancement.wizardry.crunch.desc=Crash straight through Bedrock to the Underworld above
 
+enchantment.wizardry.infusion=Infusion
+
 book.physicsbook.defaulttitle=Physics Book
 
 fluid.nacre_fluid=Nacre


### PR DESCRIPTION
In this PR a book can be infused with magic instead of a nacre pearl to get an enchanted book to be processed at an anvil further, e.g. for a meele weapon. Any subspells starting with at a touch shape are casted whenever an enemy is hit by the enchanted item.