### PR TITLE
fix #176 (mana bar overlaps with offhand if main hand is left)

### DIFF
--- a/src/main/java/com/teamwizardry/wizardry/client/core/renderer/HudRenderer.java
+++ b/src/main/java/com/teamwizardry/wizardry/client/core/renderer/HudRenderer.java
@@ -12,6 +12,7 @@ import net.minecraft.client.gui.ScaledResolution;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumHandSide;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.client.event.RenderGameOverlayEvent.ElementType;
 import net.minecraftforge.client.event.RenderGameOverlayEvent.Post;
@@ -47,7 +48,8 @@ public class HudRenderer {
 
 			GlStateManager.pushMatrix();
 			GlStateManager.color(1.0F, 1.0F, 1.0F);
-			int right = ((width / 2) - (100 / 2)) + 145;
+			int barSide = Minecraft.getMinecraft().gameSettings.mainHand == EnumHandSide.RIGHT ? 1 : -1;
+			int right = ((width / 2) - (100 / 2)) + 145 * barSide;
 			int top = height - 17;
 			emptyManaBar.draw(ClientTickHandler.getTicks(), right, top);
 			emptyBurnoutBar.draw(ClientTickHandler.getTicks(), right, top + 6);

--- a/src/main/java/com/teamwizardry/wizardry/client/core/renderer/HudRenderer.java
+++ b/src/main/java/com/teamwizardry/wizardry/client/core/renderer/HudRenderer.java
@@ -49,7 +49,7 @@ public class HudRenderer {
 			GlStateManager.pushMatrix();
 			GlStateManager.color(1.0F, 1.0F, 1.0F);
 			int barSide = Minecraft.getMinecraft().gameSettings.mainHand == EnumHandSide.RIGHT ? 1 : -1;
-			int right = ((width / 2) - (100 / 2)) + 145 * barSide;
+			int right = ((width / 2) - (100 / 2)) + 155 * barSide;
 			int top = height - 17;
 			emptyManaBar.draw(ClientTickHandler.getTicks(), right, top);
 			emptyBurnoutBar.draw(ClientTickHandler.getTicks(), right, top + 6);


### PR DESCRIPTION
I modified the hud renderer to make the mana bar side match the main hand so that it does not overlap with the offhand box as described in #176 .  

![capture](https://user-images.githubusercontent.com/1759360/46330127-f4785480-c5d6-11e8-9f6a-03a603714543.PNG)
