### PR TITLE
fix issue #190 (illumination spell can break unbreakable blocks)

### DIFF
--- a/src/main/java/com/teamwizardry/wizardry/api/util/BlockUtils.java
+++ b/src/main/java/com/teamwizardry/wizardry/api/util/BlockUtils.java
@@ -140,7 +140,8 @@ public final class BlockUtils {
 	public static boolean hasEditPermission(@Nonnull BlockPos pos, @Nonnull EntityPlayerMP player) {
 		if (FMLCommonHandler.instance().getMinecraftServerInstance().isBlockProtected(player.getEntityWorld(), pos, player))
 			return false;
-
+		IBlockState block = player.getEntityWorld().getBlockState(pos);
+		if(block.getBlockHardness(player.getEntityWorld(), pos) == -1.0F && !player.capabilities.isCreativeMode) return false;
 		for (EnumFacing e : EnumFacing.VALUES)
 			if (!player.canPlayerEdit(pos, e, player.getHeldItemMainhand()))
 				return false;


### PR DESCRIPTION
I made BlockUtils.hasEditPermission(blockpos, player) take into account if the block is unbreakable (bedrock, end portal blocks, anything with hardness of -1F).  If the player is not in creative and the block is unbreakable, it will instead return false.  This fixes https://github.com/TeamWizardry/Wizardry/issues/190, which allowed players to tunnel through bedrock by repeated use of the illumination spell.  