### PR TITLE
Spells are created from configs

### DIFF
--- a/src/main/java/com/teamwizardry/wizardry/api/capability/world/StandardWizardryWorld.java
+++ b/src/main/java/com/teamwizardry/wizardry/api/capability/world/StandardWizardryWorld.java
@@ -4,7 +4,7 @@ import com.teamwizardry.librarianlib.features.network.PacketHandler;
 import com.teamwizardry.wizardry.api.spell.IDelayedModule;
 import com.teamwizardry.wizardry.api.spell.SpellData;
 import com.teamwizardry.wizardry.api.spell.SpellRing;
-import com.teamwizardry.wizardry.api.spell.module.Module;
+import com.teamwizardry.wizardry.api.spell.module.ModuleInstance;
 import com.teamwizardry.wizardry.common.core.SpellTicker;
 import com.teamwizardry.wizardry.common.core.nemez.NemezTracker;
 import com.teamwizardry.wizardry.common.network.PacketSyncWizardryWorld;
@@ -48,7 +48,7 @@ public class StandardWizardryWorld implements WizardryWorld {
 	}
 
 	@Override
-	public void addDelayedSpell(Module module, SpellRing spellRing, SpellData data, int expiry) {
+	public void addDelayedSpell(ModuleInstance module, SpellRing spellRing, SpellData data, int expiry) {
 		if (module.getModuleClass() instanceof IDelayedModule)
 			delayedStorageSet.add(new SpellTicker.DelayedObject(module, spellRing, data, data.world.getTotalWorldTime(), expiry));
 

--- a/src/main/java/com/teamwizardry/wizardry/api/capability/world/StandardWizardryWorld.java
+++ b/src/main/java/com/teamwizardry/wizardry/api/capability/world/StandardWizardryWorld.java
@@ -49,7 +49,7 @@ public class StandardWizardryWorld implements WizardryWorld {
 
 	@Override
 	public void addDelayedSpell(Module module, SpellRing spellRing, SpellData data, int expiry) {
-		if (module instanceof IDelayedModule)
+		if (module.getModuleClass() instanceof IDelayedModule)
 			delayedStorageSet.add(new SpellTicker.DelayedObject(module, spellRing, data, data.world.getTotalWorldTime(), expiry));
 
 		PacketHandler.NETWORK.sendToDimension(new PacketSyncWizardryWorld(serializeNBT()), data.world.provider.getDimension());

--- a/src/main/java/com/teamwizardry/wizardry/api/capability/world/WizardryWorld.java
+++ b/src/main/java/com/teamwizardry/wizardry/api/capability/world/WizardryWorld.java
@@ -2,7 +2,7 @@ package com.teamwizardry.wizardry.api.capability.world;
 
 import com.teamwizardry.wizardry.api.spell.SpellData;
 import com.teamwizardry.wizardry.api.spell.SpellRing;
-import com.teamwizardry.wizardry.api.spell.module.Module;
+import com.teamwizardry.wizardry.api.spell.module.ModuleInstance;
 import com.teamwizardry.wizardry.common.core.SpellTicker;
 import com.teamwizardry.wizardry.common.core.nemez.NemezTracker;
 import net.minecraft.nbt.NBTTagCompound;
@@ -16,7 +16,7 @@ public interface WizardryWorld extends ICapabilitySerializable<NBTTagCompound> {
 
 	void addLingerSpell(SpellRing spellRing, SpellData data, int expiry);
 
-	void addDelayedSpell(Module module, SpellRing spellRing, SpellData data, int expiry);
+	void addDelayedSpell(ModuleInstance module, SpellRing spellRing, SpellData data, int expiry);
 
 	NemezTracker addNemezDrive(BlockPos pos, NemezTracker nemezDrive);
 

--- a/src/main/java/com/teamwizardry/wizardry/api/item/ICooldown.java
+++ b/src/main/java/com/teamwizardry/wizardry/api/item/ICooldown.java
@@ -29,7 +29,7 @@ public interface ICooldown {
 			if (ring.isContinuous()) return;
 
 			if (ring.getModule() instanceof IOverrideCooldown) {
-				maxCooldown = ((IOverrideCooldown) ring.getModule()).getNewCooldown(data, ring);
+				maxCooldown = ((IOverrideCooldown) ring.getModule().getModuleClass()).getNewCooldown(data, ring);
 				break;
 			}
 

--- a/src/main/java/com/teamwizardry/wizardry/api/spell/CommonWorktableModule.java
+++ b/src/main/java/com/teamwizardry/wizardry/api/spell/CommonWorktableModule.java
@@ -1,8 +1,8 @@
 package com.teamwizardry.wizardry.api.spell;
 
 import com.teamwizardry.librarianlib.features.math.Vec2d;
-import com.teamwizardry.wizardry.api.spell.module.Module;
-import com.teamwizardry.wizardry.api.spell.module.ModuleModifier;
+import com.teamwizardry.wizardry.api.spell.module.ModuleInstance;
+import com.teamwizardry.wizardry.api.spell.module.ModuleInstanceModifier;
 import com.teamwizardry.wizardry.api.spell.module.ModuleRegistry;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.common.util.INBTSerializable;
@@ -14,15 +14,15 @@ import java.util.Objects;
 
 public class CommonWorktableModule implements INBTSerializable<NBTTagCompound> {
 
-	public Module module;
+	public ModuleInstance module;
 	public Vec2d pos;
 	@Nullable
 	public CommonWorktableModule linksTo = null;
 	@Nonnull
-	public HashMap<ModuleModifier, Integer> modifiers = new HashMap<>();
+	public HashMap<ModuleInstanceModifier, Integer> modifiers = new HashMap<>();
 	public int hash = -1;
 
-	public CommonWorktableModule(int hash, Module module, Vec2d pos, @Nullable CommonWorktableModule linksTo, @Nonnull HashMap<ModuleModifier, Integer> modifiers) {
+	public CommonWorktableModule(int hash, ModuleInstance module, Vec2d pos, @Nullable CommonWorktableModule linksTo, @Nonnull HashMap<ModuleInstanceModifier, Integer> modifiers) {
 		this.hash = hash;
 		this.module = module;
 		this.pos = pos;
@@ -39,7 +39,7 @@ public class CommonWorktableModule implements INBTSerializable<NBTTagCompound> {
 		return worktableModule;
 	}
 
-	public void addModifier(ModuleModifier moduleModifier, int count) {
+	public void addModifier(ModuleInstanceModifier moduleModifier, int count) {
 		modifiers.put(moduleModifier, count);
 	}
 
@@ -79,7 +79,7 @@ public class CommonWorktableModule implements INBTSerializable<NBTTagCompound> {
 			compound.setTag("linksTo", linksTo.serializeNBT());
 
 		NBTTagCompound modifierNBT = new NBTTagCompound();
-		for (ModuleModifier modifier : modifiers.keySet()) {
+		for (ModuleInstanceModifier modifier : modifiers.keySet()) {
 			int count = modifiers.get(modifier);
 			modifierNBT.setInteger(modifier.getID(), count);
 		}
@@ -91,7 +91,7 @@ public class CommonWorktableModule implements INBTSerializable<NBTTagCompound> {
 	@Override
 	public void deserializeNBT(NBTTagCompound nbt) {
 		if (nbt.hasKey("module")) {
-			module = Module.deserialize(nbt.getString("module"));
+			module = ModuleInstance.deserialize(nbt.getString("module"));
 		}
 		if (nbt.hasKey("x") && nbt.hasKey("y")) {
 			pos = new Vec2d(nbt.getDouble("x"), nbt.getDouble("y"));
@@ -102,11 +102,11 @@ public class CommonWorktableModule implements INBTSerializable<NBTTagCompound> {
 		if (nbt.hasKey("modifiers")) {
 			modifiers = new HashMap<>();
 			for (String base : nbt.getCompoundTag("modifiers").getKeySet()) {
-				Module module = ModuleRegistry.INSTANCE.getModule(base);
-				if (!(module instanceof ModuleModifier)) continue;
+				ModuleInstance module = ModuleRegistry.INSTANCE.getModule(base);
+				if (!(module instanceof ModuleInstanceModifier)) continue;
 				int count = nbt.getCompoundTag("modifiers").getInteger(base);
 
-				modifiers.put((ModuleModifier) module, count);
+				modifiers.put((ModuleInstanceModifier) module, count);
 			}
 		}
 

--- a/src/main/java/com/teamwizardry/wizardry/api/spell/IDelayedModule.java
+++ b/src/main/java/com/teamwizardry/wizardry/api/spell/IDelayedModule.java
@@ -2,7 +2,7 @@ package com.teamwizardry.wizardry.api.spell;
 
 import com.teamwizardry.wizardry.api.capability.world.WizardryWorld;
 import com.teamwizardry.wizardry.api.capability.world.WizardryWorldCapability;
-import com.teamwizardry.wizardry.api.spell.module.Module;
+import com.teamwizardry.wizardry.api.spell.module.ModuleInstance;
 
 /**
  * Created by Demoniaque.
@@ -11,7 +11,7 @@ public interface IDelayedModule {
 
 	void runDelayedEffect(SpellData spell, SpellRing spellRing);
 
-	default void addDelayedSpell(Module module, SpellRing spellRing, SpellData data, int expiry) {
+	default void addDelayedSpell(ModuleInstance module, SpellRing spellRing, SpellData data, int expiry) {
 		WizardryWorld worldCap = WizardryWorldCapability.get(data.world);
 		worldCap.addDelayedSpell(module, spellRing, data, expiry);
 	}

--- a/src/main/java/com/teamwizardry/wizardry/api/spell/SpellBuilder.java
+++ b/src/main/java/com/teamwizardry/wizardry/api/spell/SpellBuilder.java
@@ -1,7 +1,7 @@
 package com.teamwizardry.wizardry.api.spell;
 
-import com.teamwizardry.wizardry.api.spell.module.Module;
-import com.teamwizardry.wizardry.api.spell.module.ModuleModifier;
+import com.teamwizardry.wizardry.api.spell.module.ModuleInstance;
+import com.teamwizardry.wizardry.api.spell.module.ModuleInstanceModifier;
 import com.teamwizardry.wizardry.api.spell.module.ModuleRegistry;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
@@ -53,15 +53,15 @@ public class SpellBuilder {
 
 			// Step through each item in line. If modifier, add to lastModule, if not, add to compiled.
 			for (ItemStack stack : line) {
-				Module module = ModuleRegistry.INSTANCE.getModule(stack);
+				ModuleInstance module = ModuleRegistry.INSTANCE.getModule(stack);
 
 				if (module == null) continue;
 
-				if (module instanceof ModuleModifier) {
+				if (module instanceof ModuleInstanceModifier) {
 					if (!uncompressedChain.isEmpty()) {
 						for (int i = 0; i < stack.getCount(); i++) {
 							SpellRing lastRing = uncompressedChain.peekLast();
-							lastRing.addModifier((ModuleModifier) module);
+							lastRing.addModifier((ModuleInstanceModifier) module);
 						}
 					}
 				} else {
@@ -96,9 +96,9 @@ public class SpellBuilder {
 
 		for (SpellRing ring : spellList) {
 			SpellRing chainEnd = ring;
-			List<ModuleModifier> cascadingModifiers = new LinkedList<>();
+			List<ModuleInstanceModifier> cascadingModifiers = new LinkedList<>();
 			while (chainEnd != null) {
-				for (ModuleModifier modifier : cascadingModifiers)
+				for (ModuleInstanceModifier modifier : cascadingModifiers)
 					chainEnd.addModifier(modifier);
 				if (chainEnd.getChildRing() == null) {
 					if (chainEnd.getModule() != null) {

--- a/src/main/java/com/teamwizardry/wizardry/api/spell/SpellRing.java
+++ b/src/main/java/com/teamwizardry/wizardry/api/spell/SpellRing.java
@@ -142,7 +142,7 @@ public class SpellRing implements INBTSerializable<NBTTagCompound> {
 	}
 
 	public boolean isContinuous() {
-		return module instanceof IContinuousModule;
+		return module.getModuleClass() instanceof IContinuousModule;
 	}
 
 	public Set<SpellRing> getOverridingRings() {
@@ -444,8 +444,8 @@ public class SpellRing implements INBTSerializable<NBTTagCompound> {
 	}
 
 	public int getCooldownTime(@Nullable SpellData data) {
-		if (data != null && module instanceof IOverrideCooldown)
-			return ((IOverrideCooldown) module).getNewCooldown(data, this);
+		if (data != null && module.getModuleClass() instanceof IOverrideCooldown)
+			return ((IOverrideCooldown) module.getModuleClass()).getNewCooldown(data, this);
 
 		return (int) informationTag.getDouble(AttributeRegistry.COOLDOWN.getNbtName());
 	}

--- a/src/main/java/com/teamwizardry/wizardry/api/spell/SpellRing.java
+++ b/src/main/java/com/teamwizardry/wizardry/api/spell/SpellRing.java
@@ -18,9 +18,9 @@ import com.teamwizardry.wizardry.api.spell.attribute.AttributeRange;
 import com.teamwizardry.wizardry.api.spell.attribute.AttributeRegistry;
 import com.teamwizardry.wizardry.api.spell.attribute.AttributeRegistry.Attribute;
 import com.teamwizardry.wizardry.api.spell.attribute.Operation;
-import com.teamwizardry.wizardry.api.spell.module.Module;
-import com.teamwizardry.wizardry.api.spell.module.ModuleEffect;
-import com.teamwizardry.wizardry.api.spell.module.ModuleModifier;
+import com.teamwizardry.wizardry.api.spell.module.ModuleInstance;
+import com.teamwizardry.wizardry.api.spell.module.ModuleInstanceEffect;
+import com.teamwizardry.wizardry.api.spell.module.ModuleInstanceModifier;
 import com.teamwizardry.wizardry.init.ModItems;
 import com.teamwizardry.wizardry.init.ModSounds;
 
@@ -78,7 +78,7 @@ public class SpellRing implements INBTSerializable<NBTTagCompound> {
 	 * The Module of this Ring.
 	 */
 	@Nullable
-	private Module module;
+	private ModuleInstance module;
 
 	/**
 	 * The parent ring of this Ring, the ring that will have been run before this.
@@ -95,7 +95,7 @@ public class SpellRing implements INBTSerializable<NBTTagCompound> {
 	private SpellRing() {
 	}
 
-	public SpellRing(@Nonnull Module module) {
+	public SpellRing(@Nonnull ModuleInstance module) {
 		setModule(module);
 	}
 
@@ -183,16 +183,16 @@ public class SpellRing implements INBTSerializable<NBTTagCompound> {
 	/**
 	 * If the given module is overriding this module's run
 	 */
-	public boolean isRunBeingOverridenBy(@Nonnull Module module) {
-		return this.module != null && module instanceof ModuleEffect && ((ModuleEffect) module).hasRunOverrideFor(this.module);
+	public boolean isRunBeingOverridenBy(@Nonnull ModuleInstance module) {
+		return this.module != null && module instanceof ModuleInstanceEffect && ((ModuleInstanceEffect) module).hasRunOverrideFor(this.module);
 	}
 
 	/**
 	 * If the given module is overriding this module's run
 	 */
 	@SideOnly(Side.CLIENT)
-	public boolean isRenderBeingOverridenBy(@Nonnull Module module) {
-		return this.module != null && module instanceof ModuleEffect && ((ModuleEffect) module).hasRenderOverrideFor(this.module);
+	public boolean isRenderBeingOverridenBy(@Nonnull ModuleInstance module) {
+		return this.module != null && module instanceof ModuleInstanceEffect && ((ModuleInstanceEffect) module).hasRenderOverrideFor(this.module);
 	}
 
 	//TODO: pearl holders
@@ -372,11 +372,11 @@ public class SpellRing implements INBTSerializable<NBTTagCompound> {
 	}
 
 	@Nullable
-	public Module getModule() {
+	public ModuleInstance getModule() {
 		return module;
 	}
 
-	public void setModule(@Nonnull Module module) {
+	public void setModule(@Nonnull ModuleInstance module) {
 		this.module = module;
 
 		setPrimaryColor(module.getPrimaryColor());
@@ -435,7 +435,7 @@ public class SpellRing implements INBTSerializable<NBTTagCompound> {
 		return compileTimeModifiers;
 	}
 
-	public void addModifier(ModuleModifier moduleModifier) {
+	public void addModifier(ModuleInstanceModifier moduleModifier) {
 		moduleModifier.getAttributes().forEach(modifier -> compileTimeModifiers.put(modifier.getOperation(), modifier));
 	}
 
@@ -524,7 +524,7 @@ public class SpellRing implements INBTSerializable<NBTTagCompound> {
 
 	@Override
 	public void deserializeNBT(NBTTagCompound nbt) {
-		if (nbt.hasKey("module")) this.module = Module.deserialize(nbt.getString("module"));
+		if (nbt.hasKey("module")) this.module = ModuleInstance.deserialize(nbt.getString("module"));
 		if (nbt.hasKey("extra")) informationTag = nbt.getCompoundTag("extra");
 		if (nbt.hasKey("primary_color")) primaryColor = Color.decode(nbt.getString("primary_color"));
 		if (nbt.hasKey("secondary_color")) secondaryColor = Color.decode(nbt.getString("secondary_color"));

--- a/src/main/java/com/teamwizardry/wizardry/api/spell/SpellUtils.java
+++ b/src/main/java/com/teamwizardry/wizardry/api/spell/SpellUtils.java
@@ -3,8 +3,8 @@ package com.teamwizardry.wizardry.api.spell;
 import com.teamwizardry.librarianlib.features.helpers.ItemNBTHelper;
 import com.teamwizardry.wizardry.api.Constants;
 import com.teamwizardry.wizardry.api.item.BaublesSupport;
-import com.teamwizardry.wizardry.api.spell.module.Module;
-import com.teamwizardry.wizardry.api.spell.module.ModuleModifier;
+import com.teamwizardry.wizardry.api.spell.module.ModuleInstance;
+import com.teamwizardry.wizardry.api.spell.module.ModuleInstanceModifier;
 import com.teamwizardry.wizardry.api.util.ColorUtils;
 import com.teamwizardry.wizardry.init.ModItems;
 import net.minecraft.entity.Entity;
@@ -100,10 +100,10 @@ public class SpellUtils {
 		return rings;
 	}
 	
-	public static List<List<Module>> deserializeModuleList(@Nonnull NBTTagList list)
+	public static List<List<ModuleInstance>> deserializeModuleList(@Nonnull NBTTagList list)
 	{
-		List<List<Module>> modules = new ArrayList<>();
-		List<Module> moduleList = new ArrayList<>();
+		List<List<ModuleInstance>> modules = new ArrayList<>();
+		List<ModuleInstance> moduleList = new ArrayList<>();
 		for (int i = 0; i < list.tagCount(); i++)
 		{
 			NBTBase base = list.get(i);
@@ -115,7 +115,7 @@ public class SpellUtils {
 					modules.add(moduleList);
 				moduleList = new ArrayList<>();
 			}
-			Module module = Module.deserialize(string);
+			ModuleInstance module = ModuleInstance.deserialize(string);
 			if (module == null) continue;
 			moduleList.add(module);
 		}
@@ -129,12 +129,12 @@ public class SpellUtils {
 	 * @param modules The list of spell module chains.
 	 * @return A list of required items.
 	 */
-	public static List<ItemStack> getSpellItems(List<List<Module>> modules)
+	public static List<ItemStack> getSpellItems(List<List<ModuleInstance>> modules)
 	{
 		Deque<ItemStack> items = new ArrayDeque<>();
-		for (List<Module> moduleList : modules)
+		for (List<ModuleInstance> moduleList : modules)
 		{
-			for (Module module : moduleList)
+			for (ModuleInstance module : moduleList)
 			{
 				ItemStack stack = module.getItemStack();
 				ItemStack last = items.peekLast();
@@ -156,13 +156,13 @@ public class SpellUtils {
 	 * @param modules The list of spell chains in the spell.
 	 * @return The list of spell chains containing only essential modules.
 	 */
-	public static List<List<Module>> getEssentialModules(List<List<Module>> modules)
+	public static List<List<ModuleInstance>> getEssentialModules(List<List<ModuleInstance>> modules)
 	{
-		List<List<Module>> essentialModules = new ArrayList<>();
+		List<List<ModuleInstance>> essentialModules = new ArrayList<>();
 		modules.forEach(moduleList -> {
-			List<Module> essentialList = new ArrayList<>();
+			List<ModuleInstance> essentialList = new ArrayList<>();
 			moduleList.forEach(module -> {
-				if (!(module instanceof ModuleModifier))
+				if (!(module instanceof ModuleInstanceModifier))
 					essentialList.add(module);
 			});
 			essentialModules.add(essentialList);

--- a/src/main/java/com/teamwizardry/wizardry/api/spell/module/IModule.java
+++ b/src/main/java/com/teamwizardry/wizardry/api/spell/module/IModule.java
@@ -1,0 +1,61 @@
+package com.teamwizardry.wizardry.api.spell.module;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import com.teamwizardry.wizardry.api.spell.SpellData;
+import com.teamwizardry.wizardry.api.spell.SpellRing;
+
+public interface IModule<InstanceType extends Module> {
+
+	/**
+	 * Will render whatever GL code is specified here while the spell is being held by the
+	 * player's hand.
+	 */
+	default SpellData renderVisualization(InstanceType instance, @Nonnull SpellData data, @Nonnull SpellRing ring, @Nonnull SpellData previousData) {
+		return new SpellData(data.world);
+	}
+
+	// Maybe remove from interface? Only declared in Module
+//	List<String> getDetailedInfo();
+	
+	/**
+	 * Specify all applicable modifiers that can be applied to this module.
+	 *
+	 * @return Any set with applicable ModuleModifiers.
+	 */
+	@Nullable
+	default IModuleModifier[] applicableModifiers() {
+		return null;
+	}
+	
+	default boolean ignoreResultForRendering() {
+		return false;
+	}
+
+	// Maybe remove from interface? Only declared in Module
+//	List<AttributeModifier> getAttributes();
+
+	// Maybe remove from interface? Only declared in Module
+//	Map<Attribute, AttributeRange> getAttributeRanges();
+
+	/**
+	 * A lower case snake_case string id that reflects the module to identify it during serialization/deserialization.
+	 *
+	 * @return A lower case snake_case string.
+	 */
+	String getID();
+	
+	/**
+	 * Only return false if the spellData cannot be taxed from mana. Return true otherwise.
+	 */
+	boolean run(InstanceType instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing);
+
+	/**
+	 * This method runs client side when the spellData runs. Spawn particles here.
+	 */
+	default void renderSpell(InstanceType instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+		
+	}
+
+}

--- a/src/main/java/com/teamwizardry/wizardry/api/spell/module/IModule.java
+++ b/src/main/java/com/teamwizardry/wizardry/api/spell/module/IModule.java
@@ -4,9 +4,6 @@ import javax.annotation.Nullable;
 
 public interface IModule {
 
-	// Maybe remove from interface? Only declared in Module
-//	List<String> getDetailedInfo();
-	
 	/**
 	 * Specify all applicable modifiers that can be applied to this module.
 	 *
@@ -21,17 +18,10 @@ public interface IModule {
 		return false;
 	}
 
-	// Maybe remove from interface? Only declared in Module
-//	List<AttributeModifier> getAttributes();
-
-	// Maybe remove from interface? Only declared in Module
-//	Map<Attribute, AttributeRange> getAttributeRanges();
-
 	/**
 	 * A lower case snake_case string id that reflects the module to identify it during serialization/deserialization.
 	 *
 	 * @return A lower case snake_case string.
 	 */
-	String getID();
-	
+	String getClassID();
 }

--- a/src/main/java/com/teamwizardry/wizardry/api/spell/module/IModule.java
+++ b/src/main/java/com/teamwizardry/wizardry/api/spell/module/IModule.java
@@ -1,20 +1,8 @@
 package com.teamwizardry.wizardry.api.spell.module;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import com.teamwizardry.wizardry.api.spell.SpellData;
-import com.teamwizardry.wizardry.api.spell.SpellRing;
-
-public interface IModule<InstanceType extends Module> {
-
-	/**
-	 * Will render whatever GL code is specified here while the spell is being held by the
-	 * player's hand.
-	 */
-	default SpellData renderVisualization(InstanceType instance, @Nonnull SpellData data, @Nonnull SpellRing ring, @Nonnull SpellData previousData) {
-		return new SpellData(data.world);
-	}
+public interface IModule {
 
 	// Maybe remove from interface? Only declared in Module
 //	List<String> getDetailedInfo();
@@ -46,16 +34,4 @@ public interface IModule<InstanceType extends Module> {
 	 */
 	String getID();
 	
-	/**
-	 * Only return false if the spellData cannot be taxed from mana. Return true otherwise.
-	 */
-	boolean run(InstanceType instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing);
-
-	/**
-	 * This method runs client side when the spellData runs. Spawn particles here.
-	 */
-	default void renderSpell(InstanceType instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
-		
-	}
-
 }

--- a/src/main/java/com/teamwizardry/wizardry/api/spell/module/IModuleEffect.java
+++ b/src/main/java/com/teamwizardry/wizardry/api/spell/module/IModuleEffect.java
@@ -1,8 +1,8 @@
 package com.teamwizardry.wizardry.api.spell.module;
 
-public interface IModuleEffect extends IModule, IRenderableModule<ModuleEffect>, IRunnableModule<ModuleEffect> {
+public interface IModuleEffect extends IModule, IRenderableModule<ModuleInstanceEffect>, IRunnableModule<ModuleInstanceEffect> {
 
-	default void initEffect(ModuleEffect instance) {
+	default void initEffect(ModuleInstanceEffect instance) {
 	}
 
 }

--- a/src/main/java/com/teamwizardry/wizardry/api/spell/module/IModuleEffect.java
+++ b/src/main/java/com/teamwizardry/wizardry/api/spell/module/IModuleEffect.java
@@ -1,6 +1,6 @@
 package com.teamwizardry.wizardry.api.spell.module;
 
-public interface IModuleEffect extends IModule<ModuleEffect> {
+public interface IModuleEffect extends IModule, IRenderableModule<ModuleEffect>, IRunnableModule<ModuleEffect> {
 
 	default void initEffect(ModuleEffect instance) {
 	}

--- a/src/main/java/com/teamwizardry/wizardry/api/spell/module/IModuleEffect.java
+++ b/src/main/java/com/teamwizardry/wizardry/api/spell/module/IModuleEffect.java
@@ -1,0 +1,8 @@
+package com.teamwizardry.wizardry.api.spell.module;
+
+public interface IModuleEffect extends IModule<ModuleEffect> {
+
+	default void initEffect(ModuleEffect instance) {
+	}
+
+}

--- a/src/main/java/com/teamwizardry/wizardry/api/spell/module/IModuleEvent.java
+++ b/src/main/java/com/teamwizardry/wizardry/api/spell/module/IModuleEvent.java
@@ -1,5 +1,5 @@
 package com.teamwizardry.wizardry.api.spell.module;
 
-public interface IModuleEvent extends IModule<ModuleEvent> {
+public interface IModuleEvent extends IModule, IRunnableModule<ModuleEvent> {
 
 }

--- a/src/main/java/com/teamwizardry/wizardry/api/spell/module/IModuleEvent.java
+++ b/src/main/java/com/teamwizardry/wizardry/api/spell/module/IModuleEvent.java
@@ -1,0 +1,5 @@
+package com.teamwizardry.wizardry.api.spell.module;
+
+public interface IModuleEvent extends IModule<ModuleEvent> {
+
+}

--- a/src/main/java/com/teamwizardry/wizardry/api/spell/module/IModuleModifier.java
+++ b/src/main/java/com/teamwizardry/wizardry/api/spell/module/IModuleModifier.java
@@ -1,0 +1,14 @@
+package com.teamwizardry.wizardry.api.spell.module;
+
+import javax.annotation.Nonnull;
+
+import com.teamwizardry.wizardry.api.spell.SpellData;
+import com.teamwizardry.wizardry.api.spell.SpellRing;
+
+public interface IModuleModifier extends IModule<ModuleModifier> {
+	
+	@Override
+	default boolean run(ModuleModifier instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+		return true;
+	}
+}

--- a/src/main/java/com/teamwizardry/wizardry/api/spell/module/IModuleModifier.java
+++ b/src/main/java/com/teamwizardry/wizardry/api/spell/module/IModuleModifier.java
@@ -1,14 +1,4 @@
 package com.teamwizardry.wizardry.api.spell.module;
 
-import javax.annotation.Nonnull;
-
-import com.teamwizardry.wizardry.api.spell.SpellData;
-import com.teamwizardry.wizardry.api.spell.SpellRing;
-
-public interface IModuleModifier extends IModule<ModuleModifier> {
-	
-	@Override
-	default boolean run(ModuleModifier instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
-		return true;
-	}
+public interface IModuleModifier extends IModule {
 }

--- a/src/main/java/com/teamwizardry/wizardry/api/spell/module/IModuleShape.java
+++ b/src/main/java/com/teamwizardry/wizardry/api/spell/module/IModuleShape.java
@@ -1,4 +1,4 @@
 package com.teamwizardry.wizardry.api.spell.module;
 
-public interface IModuleShape extends IModule<ModuleShape> {
+public interface IModuleShape extends IModule, IRenderableModule<ModuleShape>, IRunnableModule<ModuleShape> {
 }

--- a/src/main/java/com/teamwizardry/wizardry/api/spell/module/IModuleShape.java
+++ b/src/main/java/com/teamwizardry/wizardry/api/spell/module/IModuleShape.java
@@ -1,4 +1,4 @@
 package com.teamwizardry.wizardry.api.spell.module;
 
-public interface IModuleShape extends IModule, IRenderableModule<ModuleShape>, IRunnableModule<ModuleShape> {
+public interface IModuleShape extends IModule, IRenderableModule<ModuleInstanceShape>, IRunnableModule<ModuleInstanceShape> {
 }

--- a/src/main/java/com/teamwizardry/wizardry/api/spell/module/IModuleShape.java
+++ b/src/main/java/com/teamwizardry/wizardry/api/spell/module/IModuleShape.java
@@ -1,0 +1,4 @@
+package com.teamwizardry.wizardry.api.spell.module;
+
+public interface IModuleShape extends IModule<ModuleShape> {
+}

--- a/src/main/java/com/teamwizardry/wizardry/api/spell/module/IRenderableModule.java
+++ b/src/main/java/com/teamwizardry/wizardry/api/spell/module/IRenderableModule.java
@@ -5,7 +5,7 @@ import javax.annotation.Nonnull;
 import com.teamwizardry.wizardry.api.spell.SpellData;
 import com.teamwizardry.wizardry.api.spell.SpellRing;
 
-public interface IRenderableModule<InstanceType extends Module> {
+public interface IRenderableModule<InstanceType extends ModuleInstance> {
 	
 	/**
 	 * Will render whatever GL code is specified here while the spell is being held by the

--- a/src/main/java/com/teamwizardry/wizardry/api/spell/module/IRenderableModule.java
+++ b/src/main/java/com/teamwizardry/wizardry/api/spell/module/IRenderableModule.java
@@ -1,0 +1,24 @@
+package com.teamwizardry.wizardry.api.spell.module;
+
+import javax.annotation.Nonnull;
+
+import com.teamwizardry.wizardry.api.spell.SpellData;
+import com.teamwizardry.wizardry.api.spell.SpellRing;
+
+public interface IRenderableModule<InstanceType extends Module> {
+	
+	/**
+	 * Will render whatever GL code is specified here while the spell is being held by the
+	 * player's hand.
+	 */
+	default SpellData renderVisualization(InstanceType instance, @Nonnull SpellData data, @Nonnull SpellRing ring, @Nonnull SpellData previousData) {
+		return instance.standardRenderVisualization(data, ring, previousData);
+	}
+
+	/**
+	 * This method runs client side when the spellData runs. Spawn particles here.
+	 */
+	default void renderSpell(InstanceType instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+		
+	}
+}

--- a/src/main/java/com/teamwizardry/wizardry/api/spell/module/IRunnableModule.java
+++ b/src/main/java/com/teamwizardry/wizardry/api/spell/module/IRunnableModule.java
@@ -1,0 +1,13 @@
+package com.teamwizardry.wizardry.api.spell.module;
+
+import javax.annotation.Nonnull;
+
+import com.teamwizardry.wizardry.api.spell.SpellData;
+import com.teamwizardry.wizardry.api.spell.SpellRing;
+
+public interface IRunnableModule<InstanceType extends Module> {
+	/**
+	 * Only return false if the spellData cannot be taxed from mana. Return true otherwise.
+	 */
+	boolean run(InstanceType instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing);
+}

--- a/src/main/java/com/teamwizardry/wizardry/api/spell/module/IRunnableModule.java
+++ b/src/main/java/com/teamwizardry/wizardry/api/spell/module/IRunnableModule.java
@@ -5,7 +5,7 @@ import javax.annotation.Nonnull;
 import com.teamwizardry.wizardry.api.spell.SpellData;
 import com.teamwizardry.wizardry.api.spell.SpellRing;
 
-public interface IRunnableModule<InstanceType extends Module> {
+public interface IRunnableModule<InstanceType extends ModuleInstance> {
 	/**
 	 * Only return false if the spellData cannot be taxed from mana. Return true otherwise.
 	 */

--- a/src/main/java/com/teamwizardry/wizardry/api/spell/module/Module.java
+++ b/src/main/java/com/teamwizardry/wizardry/api/spell/module/Module.java
@@ -546,7 +546,7 @@ public abstract class Module {
 	public final boolean castSpell(@Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		if (spell.world.isRemote) return true;
 
-		if (this instanceof ILingeringModule) {
+		if (moduleClass instanceof ILingeringModule) {
 			boolean alreadyLingering = false;
 
 			WizardryWorld worldCap = WizardryWorldCapability.get(spell.world);
@@ -558,7 +558,7 @@ public abstract class Module {
 				}
 			}
 			if (!alreadyLingering)
-				worldCap.addLingerSpell(spellRing, spell, ((ILingeringModule) this).getLingeringTime(spell, spellRing));
+				worldCap.addLingerSpell(spellRing, spell, ((ILingeringModule) moduleClass).getLingeringTime(spell, spellRing));
 		}
 
 		SpellCastEvent event = new SpellCastEvent(spellRing, spell);

--- a/src/main/java/com/teamwizardry/wizardry/api/spell/module/Module.java
+++ b/src/main/java/com/teamwizardry/wizardry/api/spell/module/Module.java
@@ -4,6 +4,7 @@ import com.teamwizardry.librarianlib.core.LibrarianLib;
 import com.teamwizardry.librarianlib.core.client.ClientTickHandler;
 import com.teamwizardry.librarianlib.features.helpers.ItemNBTHelper;
 import com.teamwizardry.librarianlib.features.network.PacketHandler;
+import com.teamwizardry.wizardry.Wizardry;
 import com.teamwizardry.wizardry.api.capability.world.WizardryWorld;
 import com.teamwizardry.wizardry.api.capability.world.WizardryWorldCapability;
 import com.teamwizardry.wizardry.api.events.SpellCastEvent;
@@ -30,6 +31,7 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagString;
 import net.minecraft.nbt.NBTUtil;
 import net.minecraft.util.EnumFacing;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
@@ -57,6 +59,7 @@ public abstract class Module {
 
 	protected final String moduleName;
 	protected final IModule moduleClass;
+	protected final ResourceLocation icon;
 	protected final List<AttributeModifier> attributes = new ArrayList<>();
 	protected Map<Attribute, AttributeRange> attributeRanges = new DefaultHashMap<>(AttributeRange.BACKUP);
 	protected Color primaryColor;
@@ -76,30 +79,33 @@ public abstract class Module {
 	
 	static Module createInstance(IModule moduleClass,
 			String moduleName,
+			ResourceLocation icon,
 			ItemStack itemStack,
             Color primaryColor,
             Color secondaryColor,
             DefaultHashMap<Attribute, AttributeRange> attributeRanges) {
 		if( moduleClass instanceof IModuleEffect )
-			return new ModuleEffect((IModuleEffect)moduleClass, moduleName, itemStack, primaryColor, secondaryColor, attributeRanges);
+			return new ModuleEffect((IModuleEffect)moduleClass, moduleName, icon, itemStack, primaryColor, secondaryColor, attributeRanges);
 		else if( moduleClass instanceof IModuleModifier )
-			return new ModuleModifier((IModuleModifier)moduleClass, moduleName, itemStack, primaryColor, secondaryColor, attributeRanges);
+			return new ModuleModifier((IModuleModifier)moduleClass, moduleName, icon, itemStack, primaryColor, secondaryColor, attributeRanges);
 		else if( moduleClass instanceof IModuleEvent )
-			return new ModuleEvent((IModuleEvent)moduleClass, itemStack, moduleName, primaryColor, secondaryColor, attributeRanges);
+			return new ModuleEvent((IModuleEvent)moduleClass, itemStack, moduleName, icon, primaryColor, secondaryColor, attributeRanges);
 		else if( moduleClass instanceof IModuleShape )
-			return new ModuleShape((IModuleShape)moduleClass, itemStack, moduleName, primaryColor, secondaryColor, attributeRanges);
+			return new ModuleShape((IModuleShape)moduleClass, itemStack, moduleName, icon, primaryColor, secondaryColor, attributeRanges);
 		else
 			throw new UnsupportedOperationException("Unknown module type.");
 	}
 
 	protected Module(IModule moduleClass,
 				  String moduleName,
+				  ResourceLocation icon,
 				  ItemStack itemStack,
 	              Color primaryColor,
 	              Color secondaryColor,
 	              DefaultHashMap<Attribute, AttributeRange> attributeRanges) {
 		this.moduleClass = moduleClass;
 		this.moduleName = moduleName;
+		this.icon = icon;
 		this.itemStack = itemStack;
 		this.primaryColor = primaryColor;
 		this.secondaryColor = secondaryColor;
@@ -580,5 +586,11 @@ public abstract class Module {
 	@Nonnull
 	public final NBTTagString serialize() {
 		return new NBTTagString(moduleClass.getID());
+	}
+
+	public ResourceLocation getIconLocation() {
+		if( icon == null )
+			return new ResourceLocation(Wizardry.MODID, "textures/gui/worktable/icons/" + getID() + ".png");
+		return icon;
 	}
 }

--- a/src/main/java/com/teamwizardry/wizardry/api/spell/module/Module.java
+++ b/src/main/java/com/teamwizardry/wizardry/api/spell/module/Module.java
@@ -437,12 +437,14 @@ public abstract class Module {
 			LinkedList<ModuleModifier> applicableModifiersList = new LinkedList<>();
 			
 			IModuleModifier[] modifierClasses = moduleClass.applicableModifiers();
-			for( Module mod : ModuleRegistry.INSTANCE.modules ) {
-				IModule mc = mod.getModuleClass();
-				for( IModuleModifier modifier : modifierClasses ) {
-					if( mc.equals(modifier) ) {
-						applicableModifiersList.add((ModuleModifier)mod);	// Expected to be of type ModuleModifier
-						break;
+			if( modifierClasses != null ) {
+				for( Module mod : ModuleRegistry.INSTANCE.modules ) {
+					IModule mc = mod.getModuleClass();
+					for( IModuleModifier modifier : modifierClasses ) {
+						if( mc.getID().equals(modifier.getID()) ) {
+							applicableModifiersList.add((ModuleModifier)mod);	// Expected to be of type ModuleModifier
+							break;
+						}
 					}
 				}
 			}

--- a/src/main/java/com/teamwizardry/wizardry/api/spell/module/Module.java
+++ b/src/main/java/com/teamwizardry/wizardry/api/spell/module/Module.java
@@ -258,7 +258,7 @@ public abstract class Module {
 	 * @return A lower case snake_case string.
 	 */
 	public final String getID() {
-		return moduleClass.getID();
+		return moduleName;
 	}
 
 	@Override
@@ -280,10 +280,6 @@ public abstract class Module {
 	@Nonnull
 	public final String getNameKey() {
 		return "wizardry.spell." + moduleName + ".name";
-	}
-
-	public final String getName() {
-		return this.moduleName;
 	}
 
 	/**
@@ -447,7 +443,7 @@ public abstract class Module {
 				for( Module mod : ModuleRegistry.INSTANCE.modules ) {
 					IModule mc = mod.getModuleClass();
 					for( IModuleModifier modifier : modifierClasses ) {
-						if( mc.getID().equals(modifier.getID()) ) {
+						if( mc.getClassID().equals(modifier.getClassID()) ) {
 							applicableModifiersList.add((ModuleModifier)mod);	// Expected to be of type ModuleModifier
 							break;
 						}
@@ -585,7 +581,7 @@ public abstract class Module {
 
 	@Nonnull
 	public final NBTTagString serialize() {
-		return new NBTTagString(moduleClass.getID());
+		return new NBTTagString(getID());
 	}
 
 	public ResourceLocation getIconLocation() {

--- a/src/main/java/com/teamwizardry/wizardry/api/spell/module/ModuleEffect.java
+++ b/src/main/java/com/teamwizardry/wizardry/api/spell/module/ModuleEffect.java
@@ -14,6 +14,7 @@ import com.teamwizardry.wizardry.api.util.DefaultHashMap;
 
 import kotlin.Pair;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
@@ -22,9 +23,9 @@ public class ModuleEffect extends Module {
 	protected HashMap<String, OverrideConsumer<SpellData, SpellRing, SpellRing>> runOverrides = new HashMap<>();
 	protected HashMap<String, OverrideConsumer<SpellData, SpellRing, SpellRing>> renderOverrides = new HashMap<>();
 
-	public ModuleEffect(IModuleEffect moduleClass, String moduleName, ItemStack itemStack, Color primaryColor, Color secondaryColor,
+	public ModuleEffect(IModuleEffect moduleClass, String moduleName, ResourceLocation icon, ItemStack itemStack, Color primaryColor, Color secondaryColor,
 			DefaultHashMap<Attribute, AttributeRange> attributeRanges) {
-		super(moduleClass, moduleName, itemStack, primaryColor, secondaryColor, attributeRanges);
+		super(moduleClass, moduleName, icon, itemStack, primaryColor, secondaryColor, attributeRanges);
 		moduleClass.initEffect(this);
 	}
 	

--- a/src/main/java/com/teamwizardry/wizardry/api/spell/module/ModuleEffect.java
+++ b/src/main/java/com/teamwizardry/wizardry/api/spell/module/ModuleEffect.java
@@ -22,9 +22,9 @@ public class ModuleEffect extends Module {
 	protected HashMap<String, OverrideConsumer<SpellData, SpellRing, SpellRing>> runOverrides = new HashMap<>();
 	protected HashMap<String, OverrideConsumer<SpellData, SpellRing, SpellRing>> renderOverrides = new HashMap<>();
 
-	public ModuleEffect(IModuleEffect moduleClass, ItemStack itemStack, Color primaryColor, Color secondaryColor,
+	public ModuleEffect(IModuleEffect moduleClass, String moduleName, ItemStack itemStack, Color primaryColor, Color secondaryColor,
 			DefaultHashMap<Attribute, AttributeRange> attributeRanges) {
-		super(moduleClass, itemStack, primaryColor, secondaryColor, attributeRanges);
+		super(moduleClass, moduleName, itemStack, primaryColor, secondaryColor, attributeRanges);
 		moduleClass.initEffect(this);
 	}
 	
@@ -96,5 +96,33 @@ public class ModuleEffect extends Module {
 	@SideOnly(Side.CLIENT)
 	public OverrideConsumer<SpellData, SpellRing, SpellRing> getRenderOverrideFor(Module module) {
 		return ModuleRegistry.INSTANCE.renderOverrides.get(new Pair<>(module, this));
+	}
+	
+	/**
+	 * Only return false if the spellData cannot be taxed from mana. Return true otherwise.
+	 */
+	@Override
+	public boolean run(@Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+		return ((IModuleEffect)moduleClass).run(this, spell, spellRing);
+	}
+	
+	/**
+	 * Will render whatever GL code is specified here while the spell is being held by the
+	 * player's hand.
+	 */
+	@Override
+	@Nonnull
+	@SideOnly(Side.CLIENT)
+	public SpellData renderVisualization(@Nonnull SpellData data, @Nonnull SpellRing ring, @Nonnull SpellData previousData) {
+		return ((IModuleEffect)moduleClass).renderVisualization(this, data, ring, previousData);
+	}
+	
+	/**
+	 * This method runs client side when the spellData runs. Spawn particles here.
+	 */
+	@Override
+	@SideOnly(Side.CLIENT)
+	public void renderSpell(@Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+		((IModuleEffect)moduleClass).renderSpell(this, spell, spellRing);
 	}
 }

--- a/src/main/java/com/teamwizardry/wizardry/api/spell/module/ModuleEffect.java
+++ b/src/main/java/com/teamwizardry/wizardry/api/spell/module/ModuleEffect.java
@@ -1,5 +1,6 @@
 package com.teamwizardry.wizardry.api.spell.module;
 
+import java.awt.Color;
 import java.util.HashMap;
 
 import javax.annotation.Nonnull;
@@ -7,15 +8,25 @@ import javax.annotation.Nullable;
 
 import com.teamwizardry.wizardry.api.spell.SpellData;
 import com.teamwizardry.wizardry.api.spell.SpellRing;
+import com.teamwizardry.wizardry.api.spell.attribute.AttributeRange;
+import com.teamwizardry.wizardry.api.spell.attribute.AttributeRegistry.Attribute;
+import com.teamwizardry.wizardry.api.util.DefaultHashMap;
 
 import kotlin.Pair;
+import net.minecraft.item.ItemStack;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-public abstract class ModuleEffect extends Module {
+public class ModuleEffect extends Module {
 
 	protected HashMap<String, OverrideConsumer<SpellData, SpellRing, SpellRing>> runOverrides = new HashMap<>();
 	protected HashMap<String, OverrideConsumer<SpellData, SpellRing, SpellRing>> renderOverrides = new HashMap<>();
+
+	public ModuleEffect(IModuleEffect moduleClass, ItemStack itemStack, Color primaryColor, Color secondaryColor,
+			DefaultHashMap<Attribute, AttributeRange> attributeRanges) {
+		super(moduleClass, itemStack, primaryColor, secondaryColor, attributeRanges);
+		moduleClass.initEffect(this);
+	}
 	
 	@Nonnull
 	@Override

--- a/src/main/java/com/teamwizardry/wizardry/api/spell/module/ModuleEvent.java
+++ b/src/main/java/com/teamwizardry/wizardry/api/spell/module/ModuleEvent.java
@@ -11,12 +11,13 @@ import com.teamwizardry.wizardry.api.spell.attribute.AttributeRegistry.Attribute
 import com.teamwizardry.wizardry.api.util.DefaultHashMap;
 
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.ResourceLocation;
 
 public class ModuleEvent extends Module {
 	
-	public ModuleEvent(IModuleEvent moduleClass, ItemStack itemStack, String moduleName, Color primaryColor, Color secondaryColor,
+	public ModuleEvent(IModuleEvent moduleClass, ItemStack itemStack, String moduleName, ResourceLocation icon, Color primaryColor, Color secondaryColor,
 			DefaultHashMap<Attribute, AttributeRange> attributeRanges) {
-		super(moduleClass, moduleName, itemStack, primaryColor, secondaryColor, attributeRanges);
+		super(moduleClass, moduleName, icon, itemStack, primaryColor, secondaryColor, attributeRanges);
 	}
 
 	@Nonnull

--- a/src/main/java/com/teamwizardry/wizardry/api/spell/module/ModuleEvent.java
+++ b/src/main/java/com/teamwizardry/wizardry/api/spell/module/ModuleEvent.java
@@ -1,8 +1,22 @@
 package com.teamwizardry.wizardry.api.spell.module;
 
+import java.awt.Color;
+
 import javax.annotation.Nonnull;
 
-public abstract class ModuleEvent extends Module {
+import com.teamwizardry.wizardry.api.spell.attribute.AttributeRange;
+import com.teamwizardry.wizardry.api.spell.attribute.AttributeRegistry.Attribute;
+import com.teamwizardry.wizardry.api.util.DefaultHashMap;
+
+import net.minecraft.item.ItemStack;
+
+public class ModuleEvent extends Module {
+	
+	public ModuleEvent(IModuleEvent moduleClass, ItemStack itemStack, Color primaryColor, Color secondaryColor,
+			DefaultHashMap<Attribute, AttributeRange> attributeRanges) {
+		super(moduleClass, itemStack, primaryColor, secondaryColor, attributeRanges);
+	}
+
 	@Nonnull
 	@Override
 	public ModuleType getModuleType() {

--- a/src/main/java/com/teamwizardry/wizardry/api/spell/module/ModuleEvent.java
+++ b/src/main/java/com/teamwizardry/wizardry/api/spell/module/ModuleEvent.java
@@ -13,7 +13,7 @@ import com.teamwizardry.wizardry.api.util.DefaultHashMap;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 
-public class ModuleEvent extends Module {
+public class ModuleEvent extends ModuleInstance {
 	
 	public ModuleEvent(IModuleEvent moduleClass, ItemStack itemStack, String moduleName, ResourceLocation icon, Color primaryColor, Color secondaryColor,
 			DefaultHashMap<Attribute, AttributeRange> attributeRanges) {

--- a/src/main/java/com/teamwizardry/wizardry/api/spell/module/ModuleEvent.java
+++ b/src/main/java/com/teamwizardry/wizardry/api/spell/module/ModuleEvent.java
@@ -4,6 +4,8 @@ import java.awt.Color;
 
 import javax.annotation.Nonnull;
 
+import com.teamwizardry.wizardry.api.spell.SpellData;
+import com.teamwizardry.wizardry.api.spell.SpellRing;
 import com.teamwizardry.wizardry.api.spell.attribute.AttributeRange;
 import com.teamwizardry.wizardry.api.spell.attribute.AttributeRegistry.Attribute;
 import com.teamwizardry.wizardry.api.util.DefaultHashMap;
@@ -12,14 +14,22 @@ import net.minecraft.item.ItemStack;
 
 public class ModuleEvent extends Module {
 	
-	public ModuleEvent(IModuleEvent moduleClass, ItemStack itemStack, Color primaryColor, Color secondaryColor,
+	public ModuleEvent(IModuleEvent moduleClass, ItemStack itemStack, String moduleName, Color primaryColor, Color secondaryColor,
 			DefaultHashMap<Attribute, AttributeRange> attributeRanges) {
-		super(moduleClass, itemStack, primaryColor, secondaryColor, attributeRanges);
+		super(moduleClass, moduleName, itemStack, primaryColor, secondaryColor, attributeRanges);
 	}
 
 	@Nonnull
 	@Override
 	public ModuleType getModuleType() {
 		return ModuleType.EVENT;
+	}
+	
+	/**
+	 * Only return false if the spellData cannot be taxed from mana. Return true otherwise.
+	 */
+	@Override
+	public boolean run(@Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+		return ((IModuleEvent)moduleClass).run(this, spell, spellRing);
 	}
 }

--- a/src/main/java/com/teamwizardry/wizardry/api/spell/module/ModuleInstance.java
+++ b/src/main/java/com/teamwizardry/wizardry/api/spell/module/ModuleInstance.java
@@ -55,7 +55,7 @@ import static org.lwjgl.opengl.GL11.GL_SRC_ALPHA;
 /**
  * Created by Demoniaque.
  */
-public abstract class Module {
+public abstract class ModuleInstance {
 
 	protected final String moduleName;
 	protected final IModule moduleClass;
@@ -65,19 +65,19 @@ public abstract class Module {
 	protected Color primaryColor;
 	protected Color secondaryColor;
 	protected ItemStack itemStack;
-	protected ModuleModifier [] applicableModifiers = null;
+	protected ModuleInstanceModifier [] applicableModifiers = null;
 
 	@Nullable
-	public static Module deserialize(NBTTagString tagString) {
+	public static ModuleInstance deserialize(NBTTagString tagString) {
 		return ModuleRegistry.INSTANCE.getModule(tagString.getString());
 	}
 
 	@Nullable
-	public static Module deserialize(String id) {
+	public static ModuleInstance deserialize(String id) {
 		return ModuleRegistry.INSTANCE.getModule(id);
 	}
 	
-	static Module createInstance(IModule moduleClass,
+	static ModuleInstance createInstance(IModule moduleClass,
 			String moduleName,
 			ResourceLocation icon,
 			ItemStack itemStack,
@@ -85,18 +85,18 @@ public abstract class Module {
             Color secondaryColor,
             DefaultHashMap<Attribute, AttributeRange> attributeRanges) {
 		if( moduleClass instanceof IModuleEffect )
-			return new ModuleEffect((IModuleEffect)moduleClass, moduleName, icon, itemStack, primaryColor, secondaryColor, attributeRanges);
+			return new ModuleInstanceEffect((IModuleEffect)moduleClass, moduleName, icon, itemStack, primaryColor, secondaryColor, attributeRanges);
 		else if( moduleClass instanceof IModuleModifier )
-			return new ModuleModifier((IModuleModifier)moduleClass, moduleName, icon, itemStack, primaryColor, secondaryColor, attributeRanges);
+			return new ModuleInstanceModifier((IModuleModifier)moduleClass, moduleName, icon, itemStack, primaryColor, secondaryColor, attributeRanges);
 		else if( moduleClass instanceof IModuleEvent )
 			return new ModuleEvent((IModuleEvent)moduleClass, itemStack, moduleName, icon, primaryColor, secondaryColor, attributeRanges);
 		else if( moduleClass instanceof IModuleShape )
-			return new ModuleShape((IModuleShape)moduleClass, itemStack, moduleName, icon, primaryColor, secondaryColor, attributeRanges);
+			return new ModuleInstanceShape((IModuleShape)moduleClass, itemStack, moduleName, icon, primaryColor, secondaryColor, attributeRanges);
 		else
 			throw new UnsupportedOperationException("Unknown module type.");
 	}
 
-	protected Module(IModule moduleClass,
+	protected ModuleInstance(IModule moduleClass,
 				  String moduleName,
 				  ResourceLocation icon,
 				  ItemStack itemStack,
@@ -433,25 +433,25 @@ public abstract class Module {
 	 * @return Any set with applicable ModuleModifiers.
 	 */
 	@Nullable
-	public ModuleModifier[] applicableModifiers() {
+	public ModuleInstanceModifier[] applicableModifiers() {
 		// Find all registered compatible modifiers and return them. Results are cached.
 		if( applicableModifiers == null ) {
-			LinkedList<ModuleModifier> applicableModifiersList = new LinkedList<>();
+			LinkedList<ModuleInstanceModifier> applicableModifiersList = new LinkedList<>();
 			
 			IModuleModifier[] modifierClasses = moduleClass.applicableModifiers();
 			if( modifierClasses != null ) {
-				for( Module mod : ModuleRegistry.INSTANCE.modules ) {
+				for( ModuleInstance mod : ModuleRegistry.INSTANCE.modules ) {
 					IModule mc = mod.getModuleClass();
 					for( IModuleModifier modifier : modifierClasses ) {
 						if( mc.getClassID().equals(modifier.getClassID()) ) {
-							applicableModifiersList.add((ModuleModifier)mod);	// Expected to be of type ModuleModifier
+							applicableModifiersList.add((ModuleInstanceModifier)mod);	// Expected to be of type ModuleModifier
 							break;
 						}
 					}
 				}
 			}
 			
-			applicableModifiers = applicableModifiersList.toArray(new ModuleModifier[applicableModifiersList.size()]);
+			applicableModifiers = applicableModifiersList.toArray(new ModuleInstanceModifier[applicableModifiersList.size()]);
 		}
 		return applicableModifiers;
 	}

--- a/src/main/java/com/teamwizardry/wizardry/api/spell/module/ModuleInstanceEffect.java
+++ b/src/main/java/com/teamwizardry/wizardry/api/spell/module/ModuleInstanceEffect.java
@@ -18,12 +18,12 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-public class ModuleEffect extends Module {
+public class ModuleInstanceEffect extends ModuleInstance {
 
 	protected HashMap<String, OverrideConsumer<SpellData, SpellRing, SpellRing>> runOverrides = new HashMap<>();
 	protected HashMap<String, OverrideConsumer<SpellData, SpellRing, SpellRing>> renderOverrides = new HashMap<>();
 
-	public ModuleEffect(IModuleEffect moduleClass, String moduleName, ResourceLocation icon, ItemStack itemStack, Color primaryColor, Color secondaryColor,
+	public ModuleInstanceEffect(IModuleEffect moduleClass, String moduleName, ResourceLocation icon, ItemStack itemStack, Color primaryColor, Color secondaryColor,
 			DefaultHashMap<Attribute, AttributeRange> attributeRanges) {
 		super(moduleClass, moduleName, icon, itemStack, primaryColor, secondaryColor, attributeRanges);
 		moduleClass.initEffect(this);
@@ -79,23 +79,23 @@ public class ModuleEffect extends Module {
 		return false;
 	}
 
-	public boolean hasRunOverrideFor(Module module) {
+	public boolean hasRunOverrideFor(ModuleInstance module) {
 		return ModuleRegistry.INSTANCE.runOverrides.containsKey(new Pair<>(module, this));
 	}
 
 	@SideOnly(Side.CLIENT)
-	public boolean hasRenderOverrideFor(Module module) {
+	public boolean hasRenderOverrideFor(ModuleInstance module) {
 		return ModuleRegistry.INSTANCE.renderOverrides.containsKey(new Pair<>(module, this));
 	}
 
 	@Nullable
-	public OverrideConsumer<SpellData, SpellRing, SpellRing> getRunOverrideFor(Module module) {
+	public OverrideConsumer<SpellData, SpellRing, SpellRing> getRunOverrideFor(ModuleInstance module) {
 		return ModuleRegistry.INSTANCE.runOverrides.get(new Pair<>(module, this));
 	}
 
 	@Nullable
 	@SideOnly(Side.CLIENT)
-	public OverrideConsumer<SpellData, SpellRing, SpellRing> getRenderOverrideFor(Module module) {
+	public OverrideConsumer<SpellData, SpellRing, SpellRing> getRenderOverrideFor(ModuleInstance module) {
 		return ModuleRegistry.INSTANCE.renderOverrides.get(new Pair<>(module, this));
 	}
 	

--- a/src/main/java/com/teamwizardry/wizardry/api/spell/module/ModuleInstanceModifier.java
+++ b/src/main/java/com/teamwizardry/wizardry/api/spell/module/ModuleInstanceModifier.java
@@ -1,8 +1,6 @@
 package com.teamwizardry.wizardry.api.spell.module;
 
 import com.teamwizardry.librarianlib.core.LibrarianLib;
-import com.teamwizardry.wizardry.api.spell.SpellData;
-import com.teamwizardry.wizardry.api.spell.SpellRing;
 import com.teamwizardry.wizardry.api.spell.attribute.AttributeRange;
 import com.teamwizardry.wizardry.api.spell.attribute.AttributeRegistry.Attribute;
 import com.teamwizardry.wizardry.api.util.DefaultHashMap;
@@ -14,9 +12,9 @@ import java.awt.Color;
 
 import javax.annotation.Nonnull;
 
-public class ModuleModifier extends Module {
+public class ModuleInstanceModifier extends ModuleInstance {
 
-	public ModuleModifier(IModuleModifier moduleClass, String moduleName, ResourceLocation icon, ItemStack itemStack, Color primaryColor, Color secondaryColor,
+	public ModuleInstanceModifier(IModuleModifier moduleClass, String moduleName, ResourceLocation icon, ItemStack itemStack, Color primaryColor, Color secondaryColor,
 			DefaultHashMap<Attribute, AttributeRange> attributeRanges) {
 		super(moduleClass, moduleName, icon, itemStack, primaryColor, secondaryColor, attributeRanges);
 	}

--- a/src/main/java/com/teamwizardry/wizardry/api/spell/module/ModuleInstanceShape.java
+++ b/src/main/java/com/teamwizardry/wizardry/api/spell/module/ModuleInstanceShape.java
@@ -16,9 +16,9 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-public class ModuleShape extends Module {
+public class ModuleInstanceShape extends ModuleInstance {
 
-	public ModuleShape(IModuleShape moduleClass, ItemStack itemStack, String moduleName, ResourceLocation icon, Color primaryColor, Color secondaryColor,
+	public ModuleInstanceShape(IModuleShape moduleClass, ItemStack itemStack, String moduleName, ResourceLocation icon, Color primaryColor, Color secondaryColor,
 			DefaultHashMap<Attribute, AttributeRange> attributeRanges) {
 		super(moduleClass, moduleName, icon, itemStack, primaryColor, secondaryColor, attributeRanges);
 	}

--- a/src/main/java/com/teamwizardry/wizardry/api/spell/module/ModuleModifier.java
+++ b/src/main/java/com/teamwizardry/wizardry/api/spell/module/ModuleModifier.java
@@ -8,6 +8,7 @@ import com.teamwizardry.wizardry.api.spell.attribute.AttributeRegistry.Attribute
 import com.teamwizardry.wizardry.api.util.DefaultHashMap;
 
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.ResourceLocation;
 
 import java.awt.Color;
 
@@ -15,9 +16,9 @@ import javax.annotation.Nonnull;
 
 public class ModuleModifier extends Module {
 
-	public ModuleModifier(IModuleModifier moduleClass, String moduleName, ItemStack itemStack, Color primaryColor, Color secondaryColor,
+	public ModuleModifier(IModuleModifier moduleClass, String moduleName, ResourceLocation icon, ItemStack itemStack, Color primaryColor, Color secondaryColor,
 			DefaultHashMap<Attribute, AttributeRange> attributeRanges) {
-		super(moduleClass, moduleName, itemStack, primaryColor, secondaryColor, attributeRanges);
+		super(moduleClass, moduleName, icon, itemStack, primaryColor, secondaryColor, attributeRanges);
 	}
 
 	@Nonnull

--- a/src/main/java/com/teamwizardry/wizardry/api/spell/module/ModuleModifier.java
+++ b/src/main/java/com/teamwizardry/wizardry/api/spell/module/ModuleModifier.java
@@ -15,9 +15,9 @@ import javax.annotation.Nonnull;
 
 public class ModuleModifier extends Module {
 
-	public ModuleModifier(IModuleModifier moduleClass, ItemStack itemStack, Color primaryColor, Color secondaryColor,
+	public ModuleModifier(IModuleModifier moduleClass, String moduleName, ItemStack itemStack, Color primaryColor, Color secondaryColor,
 			DefaultHashMap<Attribute, AttributeRange> attributeRanges) {
-		super(moduleClass, itemStack, primaryColor, secondaryColor, attributeRanges);
+		super(moduleClass, moduleName, itemStack, primaryColor, secondaryColor, attributeRanges);
 	}
 
 	@Nonnull
@@ -31,7 +31,7 @@ public class ModuleModifier extends Module {
 	}
 
 	public String getShortHandKey() {
-		return "wizardry.spell." + getID() + ".short";
+		return "wizardry.spell." + moduleName + ".short";
 	}
 
 }

--- a/src/main/java/com/teamwizardry/wizardry/api/spell/module/ModuleModifier.java
+++ b/src/main/java/com/teamwizardry/wizardry/api/spell/module/ModuleModifier.java
@@ -3,10 +3,22 @@ package com.teamwizardry.wizardry.api.spell.module;
 import com.teamwizardry.librarianlib.core.LibrarianLib;
 import com.teamwizardry.wizardry.api.spell.SpellData;
 import com.teamwizardry.wizardry.api.spell.SpellRing;
+import com.teamwizardry.wizardry.api.spell.attribute.AttributeRange;
+import com.teamwizardry.wizardry.api.spell.attribute.AttributeRegistry.Attribute;
+import com.teamwizardry.wizardry.api.util.DefaultHashMap;
+
+import net.minecraft.item.ItemStack;
+
+import java.awt.Color;
 
 import javax.annotation.Nonnull;
 
-public abstract class ModuleModifier extends Module {
+public class ModuleModifier extends Module {
+
+	public ModuleModifier(IModuleModifier moduleClass, ItemStack itemStack, Color primaryColor, Color secondaryColor,
+			DefaultHashMap<Attribute, AttributeRange> attributeRanges) {
+		super(moduleClass, itemStack, primaryColor, secondaryColor, attributeRanges);
+	}
 
 	@Nonnull
 	@Override
@@ -22,13 +34,4 @@ public abstract class ModuleModifier extends Module {
 		return "wizardry.spell." + getID() + ".short";
 	}
 
-	@Override
-	public boolean run(@Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
-		return true;
-	}
-
-	@Override
-	public void renderSpell(@Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
-
-	}
 }

--- a/src/main/java/com/teamwizardry/wizardry/api/spell/module/ModuleRegistry.java
+++ b/src/main/java/com/teamwizardry/wizardry/api/spell/module/ModuleRegistry.java
@@ -43,7 +43,7 @@ public class ModuleRegistry {
 	public HashMap<Pair<ModuleShape, ModuleEffect>, OverrideConsumer<SpellData, SpellRing, SpellRing>> renderOverrides = new HashMap<>();
 	public HashMap<String, IModule> IDtoModuleClass = new HashMap<>();
 
-	private Deque<Module> left = new ArrayDeque<>();
+//	private Deque<Module> left = new ArrayDeque<>();
 
 	private ModuleRegistry() {
 	}
@@ -150,7 +150,7 @@ public class ModuleRegistry {
 			
 			String moduleID = moduleObject.get("type").getAsString();
 			IModule moduleClass = IDtoModuleClass.get(moduleID);
-			if (!moduleObject.has("type")) {
+			if (moduleClass == null) {
 				Wizardry.logger.error("| | |_ SOMETHING WENT WRONG! Referenced type " + moduleID + " is unknown.");
 				Wizardry.logger.error("| |___ Failed to parse " + fName);
 				continue;
@@ -270,8 +270,6 @@ public class ModuleRegistry {
 				}
 			}
 			
-			// TODO: Create a module
-
 			Module module = Module.createInstance(moduleClass, moduleName, new ItemStack(item, 1, itemMeta), primaryColor, secondaryColor, attributeRanges);
 
 			if (moduleObject.has("modifiers") && moduleObject.get("modifiers").isJsonArray()) {

--- a/src/main/java/com/teamwizardry/wizardry/api/spell/module/ModuleRegistry.java
+++ b/src/main/java/com/teamwizardry/wizardry/api/spell/module/ModuleRegistry.java
@@ -148,28 +148,35 @@ public class ModuleRegistry {
 				continue;
 			}
 			
-			String moduleID = moduleObject.get("type").getAsString();
-			IModule moduleClass = IDtoModuleClass.get(moduleID);
+			String moduleClassID = moduleObject.get("type").getAsString();
+			IModule moduleClass = IDtoModuleClass.get(moduleClassID);
 			if (moduleClass == null) {
-				Wizardry.logger.error("| | |_ SOMETHING WENT WRONG! Referenced type " + moduleID + " is unknown.");
+				Wizardry.logger.error("| | |_ SOMETHING WENT WRONG! Referenced type " + moduleClassID + " is unknown.");
 				Wizardry.logger.error("| |___ Failed to parse " + fName);
 				continue;
 			}
 
-			Wizardry.logger.info(" | | |_ Registering module " + moduleID);
-			
 			// Get Name
 			if (!moduleObject.has("name")) {
 				Wizardry.logger.error("| | |_ SOMETHING WENT WRONG! No 'name' key found in " + file.getName() + ". Unknown name to use for element.");
-				Wizardry.logger.error("| |___ Failed to register module " + moduleID);
+				Wizardry.logger.error("| |___ Failed to register module " + moduleClassID);
 				continue;
 			}
 			
 			String moduleName = moduleObject.get("name").getAsString();
+
+			Wizardry.logger.info(" | | |_ Registering module " + moduleName + " of class " + moduleClassID);
+			
+			// Get optional icon
+			ResourceLocation icon = null;
+			if (moduleObject.has("icon")) {
+				String iconID = moduleObject.get("icon").getAsString();
+				icon = new ResourceLocation(iconID);
+			}
 			
 			if (!moduleObject.has("item")) {
 				Wizardry.logger.error("| | |_ SOMETHING WENT WRONG! No 'item' key found in " + file.getName() + ". Unknown item to use for element.");
-				Wizardry.logger.error("| |___ Failed to register module " + moduleID);
+				Wizardry.logger.error("| |___ Failed to register module " + moduleClassID);
 				continue;
 			}
 
@@ -180,8 +187,8 @@ public class ModuleRegistry {
 
 			Item item = ForgeRegistries.ITEMS.getValue(new ResourceLocation(moduleObject.getAsJsonPrimitive("item").getAsString()));
 			if (item == null || item.getRegistryName() == null) {
-				Wizardry.logger.error("| | |_ SOMETHING WENT WRONG! Item for module " + moduleID + " does not exist '" + moduleObject.getAsJsonPrimitive("item").getAsString() + "'");
-				Wizardry.logger.error("| |___ Failed to register module " + moduleID);
+				Wizardry.logger.error("| | |_ SOMETHING WENT WRONG! Item for module " + moduleClassID + " does not exist '" + moduleObject.getAsJsonPrimitive("item").getAsString() + "'");
+				Wizardry.logger.error("| |___ Failed to register module " + moduleClassID);
 				continue;
 			} else {
 				Wizardry.logger.info(" | | |_ Found Item " + item.getRegistryName().toString());
@@ -270,7 +277,7 @@ public class ModuleRegistry {
 				}
 			}
 			
-			Module module = Module.createInstance(moduleClass, moduleName, new ItemStack(item, 1, itemMeta), primaryColor, secondaryColor, attributeRanges);
+			Module module = Module.createInstance(moduleClass, moduleName, icon, new ItemStack(item, 1, itemMeta), primaryColor, secondaryColor, attributeRanges);
 
 			if (moduleObject.has("modifiers") && moduleObject.get("modifiers").isJsonArray()) {
 				Wizardry.logger.info(" | | |___ Found Modifiers. About to process them");
@@ -307,7 +314,7 @@ public class ModuleRegistry {
 
 			modules.add(module);
 //			processed.add(moduleClass);
-			Wizardry.logger.info(" | |_ Module " + moduleID + " registered successfully!");
+			Wizardry.logger.info(" | |_ Module " + moduleClassID + " registered successfully!");
 		}
 
 /*		primary:

--- a/src/main/java/com/teamwizardry/wizardry/api/spell/module/ModuleRegistry.java
+++ b/src/main/java/com/teamwizardry/wizardry/api/spell/module/ModuleRegistry.java
@@ -38,9 +38,9 @@ public class ModuleRegistry {
 
 	public final static ModuleRegistry INSTANCE = new ModuleRegistry();
 
-	public ArrayList<Module> modules = new ArrayList<>();
-	public HashMap<Pair<ModuleShape, ModuleEffect>, OverrideConsumer<SpellData, SpellRing, SpellRing>> runOverrides = new HashMap<>();
-	public HashMap<Pair<ModuleShape, ModuleEffect>, OverrideConsumer<SpellData, SpellRing, SpellRing>> renderOverrides = new HashMap<>();
+	public ArrayList<ModuleInstance> modules = new ArrayList<>();
+	public HashMap<Pair<ModuleInstanceShape, ModuleInstanceEffect>, OverrideConsumer<SpellData, SpellRing, SpellRing>> runOverrides = new HashMap<>();
+	public HashMap<Pair<ModuleInstanceShape, ModuleInstanceEffect>, OverrideConsumer<SpellData, SpellRing, SpellRing>> renderOverrides = new HashMap<>();
 	public HashMap<String, IModule> IDtoModuleClass = new HashMap<>();
 
 //	private Deque<Module> left = new ArrayDeque<>();
@@ -48,14 +48,14 @@ public class ModuleRegistry {
 	private ModuleRegistry() {
 	}
 
-	public Module getModule(String id) {
-		for (Module module : modules) if (module.getID().equals(id)) return module;
+	public ModuleInstance getModule(String id) {
+		for (ModuleInstance module : modules) if (module.getID().equals(id)) return module;
 		return null;
 	}
 
 	@Nullable
-	public Module getModule(ItemStack itemStack) {
-		for (Module module : modules)
+	public ModuleInstance getModule(ItemStack itemStack) {
+		for (ModuleInstance module : modules)
 			if (ItemStack.areItemsEqual(itemStack, module.getItemStack())) {
 				return module;
 			}
@@ -63,18 +63,15 @@ public class ModuleRegistry {
 	}
 
 	@Nonnull
-	public ArrayList<Module> getModules(ModuleType type) {
-		ArrayList<Module> modules = new ArrayList<>();
-		for (Module module : this.modules) if (module.getModuleType() == type) modules.add(module);
+	public ArrayList<ModuleInstance> getModules(ModuleType type) {
+		ArrayList<ModuleInstance> modules = new ArrayList<>();
+		for (ModuleInstance module : this.modules) if (module.getModuleType() == type) modules.add(module);
 
-		modules.sort(Comparator.comparing(Module::getReadableName));
+		modules.sort(Comparator.comparing(ModuleInstance::getReadableName));
 		return modules;
 	}
 
 	public void loadUnprocessedModules() {
-		// TODO: Retrieve module types instead ... Modules themselves are registered then in loadModules
-		
-//		modules.clear();
 		IDtoModuleClass.clear();
 		AnnotationHelper.INSTANCE.findAnnotatedClasses(LibrarianLib.PROXY.getAsmDataTable(), IModule.class, RegisterModule.class, (clazz, info) -> {
 			try {
@@ -83,7 +80,6 @@ public class ModuleRegistry {
 				if (object instanceof IModule) {
 					IModule moduleClass = (IModule)object;
 					IDtoModuleClass.put(moduleClass.getClassID(), moduleClass);
-//					modules.add((IModule) object); 
 				}
 			} catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
 				e.printStackTrace();
@@ -96,14 +92,10 @@ public class ModuleRegistry {
 		Wizardry.logger.info(" _______________________________________________________________________\\\\");
 		Wizardry.logger.info(" | Starting module registration");
 
-//		HashSet<IModule<?>> processed = new HashSet<>();
-		
 		modules.clear();
 		
-		// TODO: Create modules for each configuration file ... Determine unbound modules ....
 		String[] files = directory.list();
 		for (String fName : files) {
-//			File file = new File(directory, module.getID() + ".json");
 			File file = new File(directory, fName);
 			
 			Wizardry.logger.info(" | |");
@@ -111,13 +103,13 @@ public class ModuleRegistry {
 
 			if (!file.exists()) {
 				Wizardry.logger.error("| | |_ SOMETHING WENT WRONG! " + file.getName() + " does NOT exist.");
-//				Wizardry.logger.error("| |___ Failed to register module " + module.getID());
+				Wizardry.logger.error("| |___ Failed to parse " + fName);
 				continue;
 			}
 
 			if (!file.canRead()) {
 				Wizardry.logger.error("| | |_ SOMETHING WENT WRONG! Something is preventing me from reading " + file.getName());
-//				Wizardry.logger.error("| |___ Failed to register module " + module.getID());
+				Wizardry.logger.error("| |___ Failed to parse " + fName);
 			}
 
 			JsonElement element;
@@ -277,7 +269,7 @@ public class ModuleRegistry {
 				}
 			}
 			
-			Module module = Module.createInstance(moduleClass, moduleName, icon, new ItemStack(item, 1, itemMeta), primaryColor, secondaryColor, attributeRanges);
+			ModuleInstance module = ModuleInstance.createInstance(moduleClass, moduleName, icon, new ItemStack(item, 1, itemMeta), primaryColor, secondaryColor, attributeRanges);
 
 			if (moduleObject.has("modifiers") && moduleObject.get("modifiers").isJsonArray()) {
 				Wizardry.logger.info(" | | |___ Found Modifiers. About to process them");
@@ -335,7 +327,7 @@ public class ModuleRegistry {
 //		modules.clear();
 //		modules.addAll(processed);
 
-		modules.sort(Comparator.comparing(Module::getID));
+		modules.sort(Comparator.comparing(ModuleInstance::getID));
 
 		Wizardry.logger.info(" |");
 		Wizardry.logger.info(" | Module registration processing complete! (ᵔᴥᵔ)");
@@ -344,25 +336,25 @@ public class ModuleRegistry {
 
 	public void loadModuleOverrides()
 	{
-		for (Module effect : getModules(ModuleType.EFFECT))
+		for (ModuleInstance effect : getModules(ModuleType.EFFECT))
 		{
-			if (!(effect instanceof ModuleEffect))
+			if (!(effect instanceof ModuleInstanceEffect))
 				continue;
 
-			((ModuleEffect) effect).runOverrides.forEach((moduleID, override) -> {
-				Module shape = getModule(moduleID);
-				if (shape instanceof ModuleShape)
+			((ModuleInstanceEffect) effect).runOverrides.forEach((moduleID, override) -> {
+				ModuleInstance shape = getModule(moduleID);
+				if (shape instanceof ModuleInstanceShape)
 				{
-					runOverrides.put(new Pair<>((ModuleShape) shape, (ModuleEffect) effect), override);
+					runOverrides.put(new Pair<>((ModuleInstanceShape) shape, (ModuleInstanceEffect) effect), override);
 					Wizardry.logger.info(" | Registered " + shape.getReadableName() + " -> " + effect.getReadableName() + " run override.");
 				}
 			});
 			
-			((ModuleEffect) effect).renderOverrides.forEach((moduleID, override) -> {
-				Module shape = getModule(moduleID);
-				if (shape instanceof ModuleShape)
+			((ModuleInstanceEffect) effect).renderOverrides.forEach((moduleID, override) -> {
+				ModuleInstance shape = getModule(moduleID);
+				if (shape instanceof ModuleInstanceShape)
 				{
-					renderOverrides.put(new Pair<>((ModuleShape) shape, (ModuleEffect) effect), override);
+					renderOverrides.put(new Pair<>((ModuleInstanceShape) shape, (ModuleInstanceEffect) effect), override);
 					Wizardry.logger.info(" | Registered " + shape.getReadableName() + " -> " + effect.getReadableName() + " renderSpell override.");
 				}
 			});
@@ -370,7 +362,7 @@ public class ModuleRegistry {
 	}
 	
 	public void copyMissingModules(File directory) {
-		for (Module module : modules) {
+		for (ModuleInstance module : modules) {
 			File file = new File(directory + "/modules/", module.getID() + ".json");
 			if (file.exists()) continue;
 
@@ -391,7 +383,7 @@ public class ModuleRegistry {
 	
 	public void copyAllModules(File directory)
 	{
-		for (Module module : modules)
+		for (ModuleInstance module : modules)
 		{
 			InputStream stream = LibrarianLib.PROXY.getResource(Wizardry.MODID, "modules/" + module.getID() + ".json");
 			if (stream == null)

--- a/src/main/java/com/teamwizardry/wizardry/api/spell/module/ModuleRegistry.java
+++ b/src/main/java/com/teamwizardry/wizardry/api/spell/module/ModuleRegistry.java
@@ -82,7 +82,7 @@ public class ModuleRegistry {
 				Object object = ctor.newInstance();
 				if (object instanceof IModule) {
 					IModule moduleClass = (IModule)object;
-					IDtoModuleClass.put(moduleClass.getID(), moduleClass);
+					IDtoModuleClass.put(moduleClass.getClassID(), moduleClass);
 //					modules.add((IModule) object); 
 				}
 			} catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
@@ -141,7 +141,7 @@ public class ModuleRegistry {
 			}
 			JsonObject moduleObject = element.getAsJsonObject();
 
-			// Get ID
+			// Get Class ID
 			if (!moduleObject.has("type")) {
 				Wizardry.logger.error("| | |_ SOMETHING WENT WRONG! No 'type' key found in " + file.getName() + ". Unknown item to use for element.");
 				Wizardry.logger.error("| |___ Failed to parse " + fName);
@@ -159,7 +159,7 @@ public class ModuleRegistry {
 			// Get Name
 			if (!moduleObject.has("name")) {
 				Wizardry.logger.error("| | |_ SOMETHING WENT WRONG! No 'name' key found in " + file.getName() + ". Unknown name to use for element.");
-				Wizardry.logger.error("| |___ Failed to register module " + moduleClassID);
+				Wizardry.logger.error("| |___ Failed to parse " + fName);
 				continue;
 			}
 			
@@ -176,7 +176,7 @@ public class ModuleRegistry {
 			
 			if (!moduleObject.has("item")) {
 				Wizardry.logger.error("| | |_ SOMETHING WENT WRONG! No 'item' key found in " + file.getName() + ". Unknown item to use for element.");
-				Wizardry.logger.error("| |___ Failed to register module " + moduleClassID);
+				Wizardry.logger.error("| |___ Failed to register module " + moduleName);
 				continue;
 			}
 
@@ -187,8 +187,8 @@ public class ModuleRegistry {
 
 			Item item = ForgeRegistries.ITEMS.getValue(new ResourceLocation(moduleObject.getAsJsonPrimitive("item").getAsString()));
 			if (item == null || item.getRegistryName() == null) {
-				Wizardry.logger.error("| | |_ SOMETHING WENT WRONG! Item for module " + moduleClassID + " does not exist '" + moduleObject.getAsJsonPrimitive("item").getAsString() + "'");
-				Wizardry.logger.error("| |___ Failed to register module " + moduleClassID);
+				Wizardry.logger.error("| | |_ SOMETHING WENT WRONG! Item for module " + moduleName + " does not exist '" + moduleObject.getAsJsonPrimitive("item").getAsString() + "'");
+				Wizardry.logger.error("| |___ Failed to register module " + moduleName);
 				continue;
 			} else {
 				Wizardry.logger.info(" | | |_ Found Item " + item.getRegistryName().toString());
@@ -314,7 +314,7 @@ public class ModuleRegistry {
 
 			modules.add(module);
 //			processed.add(moduleClass);
-			Wizardry.logger.info(" | |_ Module " + moduleClassID + " registered successfully!");
+			Wizardry.logger.info(" | |_ Module " + moduleName + " registered successfully!");
 		}
 
 /*		primary:

--- a/src/main/java/com/teamwizardry/wizardry/api/spell/module/ModuleShape.java
+++ b/src/main/java/com/teamwizardry/wizardry/api/spell/module/ModuleShape.java
@@ -1,15 +1,26 @@
 package com.teamwizardry.wizardry.api.spell.module;
 
+import java.awt.Color;
+
 import javax.annotation.Nonnull;
 
 import com.teamwizardry.wizardry.api.spell.SpellData;
 import com.teamwizardry.wizardry.api.spell.SpellRing;
+import com.teamwizardry.wizardry.api.spell.attribute.AttributeRange;
+import com.teamwizardry.wizardry.api.spell.attribute.AttributeRegistry.Attribute;
+import com.teamwizardry.wizardry.api.util.DefaultHashMap;
 
 import kotlin.Pair;
+import net.minecraft.item.ItemStack;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-public abstract class ModuleShape extends Module {
+public class ModuleShape extends Module {
+
+	public ModuleShape(IModuleShape moduleClass, ItemStack itemStack, Color primaryColor, Color secondaryColor,
+			DefaultHashMap<Attribute, AttributeRange> attributeRanges) {
+		super(moduleClass, itemStack, primaryColor, secondaryColor, attributeRanges);
+	}
 
 	@Nonnull
 	@Override

--- a/src/main/java/com/teamwizardry/wizardry/api/spell/module/ModuleShape.java
+++ b/src/main/java/com/teamwizardry/wizardry/api/spell/module/ModuleShape.java
@@ -12,14 +12,15 @@ import com.teamwizardry.wizardry.api.util.DefaultHashMap;
 
 import kotlin.Pair;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
 public class ModuleShape extends Module {
 
-	public ModuleShape(IModuleShape moduleClass, ItemStack itemStack, String moduleName, Color primaryColor, Color secondaryColor,
+	public ModuleShape(IModuleShape moduleClass, ItemStack itemStack, String moduleName, ResourceLocation icon, Color primaryColor, Color secondaryColor,
 			DefaultHashMap<Attribute, AttributeRange> attributeRanges) {
-		super(moduleClass, moduleName, itemStack, primaryColor, secondaryColor, attributeRanges);
+		super(moduleClass, moduleName, icon, itemStack, primaryColor, secondaryColor, attributeRanges);
 	}
 
 	@Nonnull

--- a/src/main/java/com/teamwizardry/wizardry/api/spell/module/ModuleShape.java
+++ b/src/main/java/com/teamwizardry/wizardry/api/spell/module/ModuleShape.java
@@ -17,9 +17,9 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 
 public class ModuleShape extends Module {
 
-	public ModuleShape(IModuleShape moduleClass, ItemStack itemStack, Color primaryColor, Color secondaryColor,
+	public ModuleShape(IModuleShape moduleClass, ItemStack itemStack, String moduleName, Color primaryColor, Color secondaryColor,
 			DefaultHashMap<Attribute, AttributeRange> attributeRanges) {
-		super(moduleClass, itemStack, primaryColor, secondaryColor, attributeRanges);
+		super(moduleClass, moduleName, itemStack, primaryColor, secondaryColor, attributeRanges);
 	}
 
 	@Nonnull
@@ -54,6 +54,32 @@ public class ModuleShape extends Module {
 		}
 		return overriden;
 	}
+	
+	/**
+	 * Only return false if the spellData cannot be taxed from mana. Return true otherwise.
+	 */
+	@Override
+	public boolean run(@Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+		return ((IModuleShape)moduleClass).run(this, spell, spellRing);
+	}
 
-
+	/**
+	 * Will render whatever GL code is specified here while the spell is being held by the
+	 * player's hand.
+	 */
+	@Override
+	@Nonnull
+	@SideOnly(Side.CLIENT)
+	public SpellData renderVisualization(@Nonnull SpellData data, @Nonnull SpellRing ring, @Nonnull SpellData previousData) {
+		return ((IModuleShape)moduleClass).renderVisualization(this, data, ring, previousData);
+	}
+	
+	/**
+	 * This method runs client side when the spellData runs. Spawn particles here.
+	 */
+	@Override
+	@SideOnly(Side.CLIENT)
+	public void renderSpell(@Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+		((IModuleShape)moduleClass).renderSpell(this, spell, spellRing);
+	}
 }

--- a/src/main/java/com/teamwizardry/wizardry/api/util/BlockUtils.java
+++ b/src/main/java/com/teamwizardry/wizardry/api/util/BlockUtils.java
@@ -7,11 +7,13 @@ import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumActionResult;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumFacing.Axis;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldServer;
 import net.minecraftforge.common.ForgeHooks;
@@ -193,6 +195,14 @@ public final class BlockUtils {
 	public static Set<BlockPos> blocksInSquare(BlockPos center, EnumFacing facing, int maxBlocks, int maxRange, Predicate<BlockPos> ignore)
 	{
 		return blocksInSquare(center, facing.getAxis(), maxBlocks, maxRange, ignore);
+	}
+	
+	@SuppressWarnings("unchecked")
+	public static <T extends TileEntity> T getTileEntity(IBlockAccess world, BlockPos pos, Class<T> clazz) {
+		TileEntity te = world.getTileEntity(pos);
+		if( !clazz.isInstance(te) )
+			return null;
+		return (T)te;
 	}
 
 }

--- a/src/main/java/com/teamwizardry/wizardry/client/core/renderer/SpellVisualizationRenderer.java
+++ b/src/main/java/com/teamwizardry/wizardry/client/core/renderer/SpellVisualizationRenderer.java
@@ -6,7 +6,7 @@ import com.teamwizardry.wizardry.api.item.ICooldown;
 import com.teamwizardry.wizardry.api.spell.SpellData;
 import com.teamwizardry.wizardry.api.spell.SpellRing;
 import com.teamwizardry.wizardry.api.spell.SpellUtils;
-import com.teamwizardry.wizardry.api.spell.module.Module;
+import com.teamwizardry.wizardry.api.spell.module.ModuleInstance;
 import com.teamwizardry.wizardry.init.ModItems;
 import net.minecraft.client.Minecraft;
 import net.minecraft.entity.player.EntityPlayer;
@@ -24,7 +24,7 @@ import java.util.Set;
 @Mod.EventBusSubscriber(modid = Wizardry.MODID, value = Side.CLIENT)
 public class SpellVisualizationRenderer {
 
-	private static HashMap<Module, SpellData> previousTickCache = new HashMap<>();
+	private static HashMap<ModuleInstance, SpellData> previousTickCache = new HashMap<>();
 
 	@SubscribeEvent
 	public static void tickDisplay(CustomWorldRenderEvent event) {
@@ -40,7 +40,7 @@ public class SpellVisualizationRenderer {
 
 		List<SpellRing> chains = SpellUtils.getSpellChains(hand);
 
-		Set<Module> untransientModules = new HashSet<>();
+		Set<ModuleInstance> untransientModules = new HashSet<>();
 
 		for (SpellRing chain : chains) {
 
@@ -69,8 +69,8 @@ public class SpellVisualizationRenderer {
 			}
 		}
 
-		Set<Module> tmp = new HashSet<>(previousTickCache.keySet());
-		for (Module module : tmp) {
+		Set<ModuleInstance> tmp = new HashSet<>(previousTickCache.keySet());
+		for (ModuleInstance module : tmp) {
 			if (!untransientModules.contains(module)) {
 				previousTickCache.remove(module);
 			}

--- a/src/main/java/com/teamwizardry/wizardry/client/gui/book/ComponentSpellRecipe.java
+++ b/src/main/java/com/teamwizardry/wizardry/client/gui/book/ComponentSpellRecipe.java
@@ -14,7 +14,7 @@ import com.teamwizardry.librarianlib.features.gui.provided.book.hierarchy.book.B
 import com.teamwizardry.librarianlib.features.helpers.ItemNBTHelper;
 import com.teamwizardry.wizardry.api.Constants;
 import com.teamwizardry.wizardry.api.spell.SpellUtils;
-import com.teamwizardry.wizardry.api.spell.module.Module;
+import com.teamwizardry.wizardry.api.spell.module.ModuleInstance;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.item.ItemStack;
@@ -65,7 +65,7 @@ public class ComponentSpellRecipe implements IBookElement {
 		NBTTagList moduleList = ItemNBTHelper.getList(bookStack, Constants.NBT.SPELL, net.minecraftforge.common.util.Constants.NBT.TAG_STRING);
 		if (moduleList == null) return contexts;
 
-		List<List<Module>> spellModules = SpellUtils.deserializeModuleList(moduleList);
+		List<List<ModuleInstance>> spellModules = SpellUtils.deserializeModuleList(moduleList);
 		List<ItemStack> spellItems = SpellUtils.getSpellItems(spellModules);
 		spellModules = SpellUtils.getEssentialModules(spellModules);
 
@@ -73,9 +73,9 @@ public class ComponentSpellRecipe implements IBookElement {
 
 		int widthOfSpace = fr.getStringWidth(" ");
 		StringBuilder builder = new StringBuilder(LibrarianLib.PROXY.translate("wizardry.book.spell_recipe_structure") + "\n");
-		for (List<Module> spellModuleList : spellModules) {
+		for (List<ModuleInstance> spellModuleList : spellModules) {
 			String margin = null;
-			for (Module module : spellModuleList) {
+			for (ModuleInstance module : spellModuleList) {
 				if (margin == null) {
 					margin = " - ";
 					builder.append(margin).append(module.getReadableName()).append("\n");

--- a/src/main/java/com/teamwizardry/wizardry/client/gui/worktable/ComponentModifiers.java
+++ b/src/main/java/com/teamwizardry/wizardry/client/gui/worktable/ComponentModifiers.java
@@ -12,8 +12,8 @@ import com.teamwizardry.librarianlib.features.gui.component.GuiComponentEvents;
 import com.teamwizardry.librarianlib.features.gui.components.ComponentRect;
 import com.teamwizardry.librarianlib.features.gui.components.ComponentText;
 import com.teamwizardry.librarianlib.features.math.Vec2d;
-import com.teamwizardry.wizardry.api.spell.module.Module;
-import com.teamwizardry.wizardry.api.spell.module.ModuleModifier;
+import com.teamwizardry.wizardry.api.spell.module.ModuleInstance;
+import com.teamwizardry.wizardry.api.spell.module.ModuleInstanceModifier;
 import com.teamwizardry.wizardry.api.util.RandUtil;
 import com.teamwizardry.wizardry.init.ModSounds;
 import net.minecraft.client.Minecraft;
@@ -89,15 +89,15 @@ public class ComponentModifiers extends GuiComponent {
 				return;
 			}
 
-			Module module = selectedModule.getModule();
+			ModuleInstance module = selectedModule.getModule();
 
-			ModuleModifier[] applicableModifiers = module.applicableModifiers();
+			ModuleInstanceModifier[] applicableModifiers = module.applicableModifiers();
 			if (applicableModifiers == null || applicableModifiers.length <= 0) {
 				animationPlaying = false;
 				return;
 			}
 
-			ModuleModifier[] modifiers = module.applicableModifiers();
+			ModuleInstanceModifier[] modifiers = module.applicableModifiers();
 			if (modifiers == null) {
 				animationPlaying = false;
 				return;
@@ -115,7 +115,7 @@ public class ComponentModifiers extends GuiComponent {
 				int lengthToTravel = (i + 1) * PIXELS_PER_BAR; // units: pixels
 				float slideDuration = outDuration * lengthToTravel / slideOutDist; // units: ticks
 
-				ModuleModifier modifier = modifiers[i];
+				ModuleInstanceModifier modifier = modifiers[i];
 
 				ComponentRect bar = new ComponentRect(0, 0, getSize().getXi(), PIXELS_PER_BAR);
 				bar.getColor().setValue(new Color(0x80000000, true));

--- a/src/main/java/com/teamwizardry/wizardry/client/gui/worktable/TableModule.java
+++ b/src/main/java/com/teamwizardry/wizardry/client/gui/worktable/TableModule.java
@@ -69,7 +69,7 @@ public class TableModule extends GuiComponent {
 		this.worktable = worktable;
 		this.module = module;
 		this.draggable = draggable;
-		icon = new Sprite(new ResourceLocation(Wizardry.MODID, "textures/gui/worktable/icons/" + module.getID() + ".png"));
+		icon = new Sprite(module.getIconLocation());
 		this.benign = enableTooltip = benign;
 
 		initialPos = thisPosToOtherContext(null);

--- a/src/main/java/com/teamwizardry/wizardry/client/gui/worktable/TableModule.java
+++ b/src/main/java/com/teamwizardry/wizardry/client/gui/worktable/TableModule.java
@@ -14,8 +14,8 @@ import com.teamwizardry.librarianlib.features.math.Vec2d;
 import com.teamwizardry.librarianlib.features.math.interpolate.position.InterpBezier2D;
 import com.teamwizardry.librarianlib.features.sprite.Sprite;
 import com.teamwizardry.wizardry.Wizardry;
-import com.teamwizardry.wizardry.api.spell.module.Module;
-import com.teamwizardry.wizardry.api.spell.module.ModuleModifier;
+import com.teamwizardry.wizardry.api.spell.module.ModuleInstance;
+import com.teamwizardry.wizardry.api.spell.module.ModuleInstanceModifier;
 import com.teamwizardry.wizardry.api.spell.module.ModuleRegistry;
 import com.teamwizardry.wizardry.api.spell.module.ModuleType;
 import com.teamwizardry.wizardry.init.ModSounds;
@@ -52,7 +52,7 @@ public class TableModule extends GuiComponent {
 	@Nonnull
 	private final WorktableGui worktable;
 	@Nonnull
-	private final Module module;
+	private final ModuleInstance module;
 	private final boolean draggable;
 	private final Sprite icon;
 	private final boolean benign;
@@ -64,7 +64,7 @@ public class TableModule extends GuiComponent {
 	 * ALWAYS from the context of null. Never to any other component.
 	 */
 	private Vec2d initialPos;
-	public TableModule(@Nonnull WorktableGui worktable, @Nonnull Module module, boolean draggable, boolean benign) {
+	public TableModule(@Nonnull WorktableGui worktable, @Nonnull ModuleInstance module, boolean draggable, boolean benign) {
 		super(0, 0, PLATE.getWidth(), PLATE.getHeight());
 		this.worktable = worktable;
 		this.module = module;
@@ -475,20 +475,20 @@ public class TableModule extends GuiComponent {
 		icon.bind();
 		icon.draw(0, shrink / 2.0f, shrink / 2.0f, getSize().getXf() - shrink, getSize().getYf() - shrink);
 
-		HashMap<ModuleModifier, Integer> modifiers = new HashMap<>();
-		List<ModuleModifier> modifierList = new ArrayList<>();
-		for (Module module : ModuleRegistry.INSTANCE.getModules(ModuleType.MODIFIER)) {
-			if (!(module instanceof ModuleModifier)) continue;
+		HashMap<ModuleInstanceModifier, Integer> modifiers = new HashMap<>();
+		List<ModuleInstanceModifier> modifierList = new ArrayList<>();
+		for (ModuleInstance module : ModuleRegistry.INSTANCE.getModules(ModuleType.MODIFIER)) {
+			if (!(module instanceof ModuleInstanceModifier)) continue;
 			if (!hasData(Integer.class, module.getID())) continue;
 
-			modifiers.put((ModuleModifier) module, getData(Integer.class, module.getID()));
-			modifierList.add((ModuleModifier) module);
+			modifiers.put((ModuleInstanceModifier) module, getData(Integer.class, module.getID()));
+			modifierList.add((ModuleInstanceModifier) module);
 		}
 
 		int count = modifierList.size();
 		for (int i = 0; i < count; i++) {
 
-			ModuleModifier modifier = modifierList.get(i);
+			ModuleInstanceModifier modifier = modifierList.get(i);
 
 			Vec2d modSize = getSize().mul(0.75f);
 
@@ -564,7 +564,7 @@ public class TableModule extends GuiComponent {
 	}
 
 	@Nonnull
-	public Module getModule() {
+	public ModuleInstance getModule() {
 		return module;
 	}
 

--- a/src/main/java/com/teamwizardry/wizardry/client/gui/worktable/WorktableGui.java
+++ b/src/main/java/com/teamwizardry/wizardry/client/gui/worktable/WorktableGui.java
@@ -23,8 +23,8 @@ import com.teamwizardry.wizardry.api.spell.CommonWorktableModule;
 import com.teamwizardry.wizardry.api.spell.SpellBuilder;
 import com.teamwizardry.wizardry.api.spell.SpellRing;
 import com.teamwizardry.wizardry.api.spell.SpellUtils;
-import com.teamwizardry.wizardry.api.spell.module.Module;
-import com.teamwizardry.wizardry.api.spell.module.ModuleModifier;
+import com.teamwizardry.wizardry.api.spell.module.ModuleInstance;
+import com.teamwizardry.wizardry.api.spell.module.ModuleInstanceModifier;
 import com.teamwizardry.wizardry.api.spell.module.ModuleRegistry;
 import com.teamwizardry.wizardry.api.spell.module.ModuleType;
 import com.teamwizardry.wizardry.api.util.RandUtil;
@@ -85,7 +85,7 @@ public class WorktableGui extends GuiBase {
 	private ComponentSprite tableComponent;
 	private boolean hadBook = false, bookWarnRevised = false;
 	protected Set<CommonWorktableModule> commonModules = new HashSet<>();
-	private List<List<Module>> chains = new ArrayList<>();
+	private List<List<ModuleInstance>> chains = new ArrayList<>();
 	private boolean canBeSaved = false;
 
 	@NotNull
@@ -205,7 +205,7 @@ public class WorktableGui extends GuiBase {
 				chains.clear();
 
 				for (TableModule head : getSpellHeads()) {
-					List<Module> chain = new ArrayList<>();
+					List<ModuleInstance> chain = new ArrayList<>();
 
 					TableModule lastModule = head;
 					CommonWorktableModule lastCommonModule = new CommonWorktableModule(lastModule.hashCode(), lastModule.getModule(), lastModule.getPos(), null, new HashMap<>());
@@ -221,8 +221,8 @@ public class WorktableGui extends GuiBase {
 							lastCommonModule = commonModule;
 						}
 
-						for (Module module : ModuleRegistry.INSTANCE.getModules(ModuleType.MODIFIER)) {
-							if (!(module instanceof ModuleModifier)) continue;
+						for (ModuleInstance module : ModuleRegistry.INSTANCE.getModules(ModuleType.MODIFIER)) {
+							if (!(module instanceof ModuleInstanceModifier)) continue;
 							if (!lastModule.hasData(Integer.class, module.getID())) continue;
 
 							int count = lastModule.getData(Integer.class, module.getID());
@@ -231,7 +231,7 @@ public class WorktableGui extends GuiBase {
 								chain.add(module);
 							}
 
-							lastCommonModule.addModifier((ModuleModifier) module, count);
+							lastCommonModule.addModifier((ModuleInstanceModifier) module, count);
 						}
 
 						lastModule = lastModule.getLinksTo();
@@ -545,7 +545,7 @@ public class WorktableGui extends GuiBase {
 						DragMixin drag = new DragMixin(lastModule, vec2d -> vec2d);
 						drag.setDragOffset(new Vec2d(6, 6));
 
-						for (ModuleModifier modifier : commonModule.modifiers.keySet()) {
+						for (ModuleInstanceModifier modifier : commonModule.modifiers.keySet()) {
 							lastModule.setData(Integer.class, modifier.getID(), commonModule.modifiers.get(modifier));
 						}
 
@@ -579,13 +579,13 @@ public class WorktableGui extends GuiBase {
 					lastCommonModule = commonModule;
 				}
 
-				for (Module module : ModuleRegistry.INSTANCE.getModules(ModuleType.MODIFIER)) {
-					if (!(module instanceof ModuleModifier)) continue;
+				for (ModuleInstance module : ModuleRegistry.INSTANCE.getModules(ModuleType.MODIFIER)) {
+					if (!(module instanceof ModuleInstanceModifier)) continue;
 					if (!lastModule.hasData(Integer.class, module.getID())) continue;
 
 					int count = lastModule.getData(Integer.class, module.getID());
 
-					lastCommonModule.addModifier((ModuleModifier) module, count);
+					lastCommonModule.addModifier((ModuleInstanceModifier) module, count);
 				}
 
 				lastModule = lastModule.getLinksTo();
@@ -613,17 +613,17 @@ public class WorktableGui extends GuiBase {
 	}
 
 	public String getSpellName() {
-		List<List<Module>> chains = new ArrayList<>();
+		List<List<ModuleInstance>> chains = new ArrayList<>();
 		for (TableModule head : getSpellHeads()) {
-			List<Module> chain = new ArrayList<>();
+			List<ModuleInstance> chain = new ArrayList<>();
 
 			TableModule lastModule = head;
 
 			while (lastModule != null) {
 				chain.add(lastModule.getModule());
 
-				for (Module module : ModuleRegistry.INSTANCE.getModules(ModuleType.MODIFIER)) {
-					if (!(module instanceof ModuleModifier)) continue;
+				for (ModuleInstance module : ModuleRegistry.INSTANCE.getModules(ModuleType.MODIFIER)) {
+					if (!(module instanceof ModuleInstanceModifier)) continue;
 					if (!lastModule.hasData(Integer.class, module.getID())) continue;
 
 					int count = lastModule.getData(Integer.class, module.getID());
@@ -721,7 +721,7 @@ public class WorktableGui extends GuiBase {
 
 	private void addModules(ComponentSprite parent, ModuleType type) {
 		int column = 0, row = 0;
-		for (Module module : ModuleRegistry.INSTANCE.getModules(type)) {
+		for (ModuleInstance module : ModuleRegistry.INSTANCE.getModules(type)) {
 			TableModule tableModule = new TableModule(this, module, false, false);
 			tableModule.setPos(new Vec2d(row * 16, column * 16));
 			parent.add(tableModule);
@@ -832,7 +832,7 @@ public class WorktableGui extends GuiBase {
 					fakeModule.getTransform().setTranslateZ(230);
 					fakePaper.add(fakeModule);
 
-					for (Module module : ModuleRegistry.INSTANCE.getModules(ModuleType.MODIFIER)) {
+					for (ModuleInstance module : ModuleRegistry.INSTANCE.getModules(ModuleType.MODIFIER)) {
 						if (tableModule.hasData(Integer.class, module.getID())) {
 							fakeModule.setData(Integer.class, module.getID(), tableModule.getData(Integer.class, module.getID()));
 						}
@@ -1049,7 +1049,7 @@ public class WorktableGui extends GuiBase {
 
 						lastModule.setData(Vec2d.class, "true_pos", commonModule.pos);
 
-						for (ModuleModifier modifier : commonModule.modifiers.keySet()) {
+						for (ModuleInstanceModifier modifier : commonModule.modifiers.keySet()) {
 							lastModule.setData(Integer.class, modifier.getID(), commonModule.modifiers.get(modifier));
 						}
 

--- a/src/main/java/com/teamwizardry/wizardry/client/render/item/RenderCodex.java
+++ b/src/main/java/com/teamwizardry/wizardry/client/render/item/RenderCodex.java
@@ -9,7 +9,7 @@ import com.teamwizardry.librarianlib.features.sprite.Sprite;
 import com.teamwizardry.wizardry.Wizardry;
 import com.teamwizardry.wizardry.api.Constants;
 import com.teamwizardry.wizardry.api.spell.SpellUtils;
-import com.teamwizardry.wizardry.api.spell.module.Module;
+import com.teamwizardry.wizardry.api.spell.module.ModuleInstance;
 import com.teamwizardry.wizardry.api.util.RandUtil;
 import com.teamwizardry.wizardry.client.gui.book.GuiBook;
 import com.teamwizardry.wizardry.init.ModItems;
@@ -456,7 +456,7 @@ public class RenderCodex {
 		NBTTagList moduleList = ItemNBTHelper.getList(stack, Constants.NBT.SPELL, net.minecraftforge.common.util.Constants.NBT.TAG_STRING);
 		if (moduleList == null) return new String[0];
 
-		List<List<Module>> spellModules = SpellUtils.deserializeModuleList(moduleList);
+		List<List<ModuleInstance>> spellModules = SpellUtils.deserializeModuleList(moduleList);
 		spellModules = SpellUtils.getEssentialModules(spellModules);
 		int page = ItemNBTHelper.getInt(stack, "page", 0);
 
@@ -464,9 +464,9 @@ public class RenderCodex {
 
 		int widthOfSpace = fr.getStringWidth(" ");
 		StringBuilder builder = new StringBuilder("Spell Structure:\n");
-		for (List<Module> spellModuleList : spellModules) {
+		for (List<ModuleInstance> spellModuleList : spellModules) {
 			String margin = null;
-			for (Module module : spellModuleList) {
+			for (ModuleInstance module : spellModuleList) {
 				if (margin == null) {
 					margin = " - ";
 					builder.append(margin).append(module.getReadableName()).append("\n");

--- a/src/main/java/com/teamwizardry/wizardry/common/command/CommandWizardry.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/command/CommandWizardry.java
@@ -2,8 +2,8 @@ package com.teamwizardry.wizardry.common.command;
 
 import com.teamwizardry.librarianlib.features.network.PacketHandler;
 import com.teamwizardry.wizardry.api.spell.attribute.AttributeModifier;
-import com.teamwizardry.wizardry.api.spell.module.Module;
-import com.teamwizardry.wizardry.api.spell.module.ModuleModifier;
+import com.teamwizardry.wizardry.api.spell.module.ModuleInstance;
+import com.teamwizardry.wizardry.api.spell.module.ModuleInstanceModifier;
 import com.teamwizardry.wizardry.api.spell.module.ModuleRegistry;
 import com.teamwizardry.wizardry.common.network.PacketSyncModules;
 import com.teamwizardry.wizardry.proxy.CommonProxy;
@@ -97,7 +97,7 @@ public class CommandWizardry extends CommandBase {
 
 			notifyCommandListener(sender, this, TextFormatting.YELLOW + " ________________________________________________\\\\");
 			notifyCommandListener(sender, this, TextFormatting.YELLOW + " | " + TextFormatting.GRAY + "Module List");
-			for (Module module : ModuleRegistry.INSTANCE.modules) {
+			for (ModuleInstance module : ModuleRegistry.INSTANCE.modules) {
 				notifyCommandListener(sender, this, TextFormatting.YELLOW + " | |_ " + TextFormatting.GREEN + module.getID() + TextFormatting.RESET + ": " + TextFormatting.GRAY + module.getReadableName());
 			}
 			notifyCommandListener(sender, this, TextFormatting.YELLOW + " |________________________________________________//");
@@ -105,7 +105,7 @@ public class CommandWizardry extends CommandBase {
 		} else if (args[0].equalsIgnoreCase("debug")) {
 			if (args.length < 2) throw new WrongUsageException(getUsage(sender));
 
-			Module module = ModuleRegistry.INSTANCE.getModule(args[1]);
+			ModuleInstance module = ModuleRegistry.INSTANCE.getModule(args[1]);
 
 			if (module == null) {
 				notifyCommandListener(sender, this, "Module not found.");
@@ -131,10 +131,10 @@ public class CommandWizardry extends CommandBase {
 			for (AttributeModifier attributeModifier : module.getAttributes())
 				notifyCommandListener(sender, this, TextFormatting.YELLOW + " |  |  |_ " + TextFormatting.GRAY + attributeModifier.toString());
 
-			ModuleModifier[] modifierList = module.applicableModifiers();
+			ModuleInstanceModifier[] modifierList = module.applicableModifiers();
 			if (modifierList != null) {
 				notifyCommandListener(sender, this, TextFormatting.YELLOW + " |  |_ " + TextFormatting.GREEN + "Applicable Modifiers ");
-				for (ModuleModifier modifier : modifierList)
+				for (ModuleInstanceModifier modifier : modifierList)
 					notifyCommandListener(sender, this, TextFormatting.YELLOW + " |     |_ " + TextFormatting.DARK_GREEN + modifier.getID());
 			}
 			notifyCommandListener(sender, this, TextFormatting.YELLOW + " |________________________________________________//");

--- a/src/main/java/com/teamwizardry/wizardry/common/core/EventHandler.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/core/EventHandler.java
@@ -134,7 +134,7 @@ public class EventHandler {
 		Entity caster = event.getSpellData().getData(SpellData.DefaultKeys.CASTER);
 		int chance = 5;
 		for (SpellRing spellRing : SpellUtils.getAllSpellRings(event.getSpellRing()))
-			if (spellRing instanceof IContinuousModule) {
+			if (spellRing.getModule().getModuleClass() instanceof IContinuousModule) {
 				chance = 1000;
 				break;
 			}

--- a/src/main/java/com/teamwizardry/wizardry/common/core/SpellTicker.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/core/SpellTicker.java
@@ -7,7 +7,7 @@ import com.teamwizardry.wizardry.api.capability.world.WizardryWorldCapability;
 import com.teamwizardry.wizardry.api.spell.IDelayedModule;
 import com.teamwizardry.wizardry.api.spell.SpellData;
 import com.teamwizardry.wizardry.api.spell.SpellRing;
-import com.teamwizardry.wizardry.api.spell.module.Module;
+import com.teamwizardry.wizardry.api.spell.module.ModuleInstance;
 import com.teamwizardry.wizardry.common.network.PacketSyncWizardryWorld;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.World;
@@ -151,7 +151,7 @@ public class SpellTicker {
 
 	public static class DelayedObject implements INBTSerializable<NBTTagCompound> {
 
-		private Module module;
+		private ModuleInstance module;
 		private SpellRing spellRing;
 		private SpellData spellData;
 		private long worldTime;
@@ -160,7 +160,7 @@ public class SpellTicker {
 		@NotNull
 		private final World world;
 
-		public DelayedObject(Module module, SpellRing spellRing, SpellData spellData, long worldTime, int expiry) {
+		public DelayedObject(ModuleInstance module, SpellRing spellRing, SpellData spellData, long worldTime, int expiry) {
 			this.module = module;
 			this.spellRing = spellRing;
 			this.spellData = spellData;
@@ -195,7 +195,7 @@ public class SpellTicker {
 			return object;
 		}
 
-		public Module getModule() {
+		public ModuleInstance getModule() {
 			return module;
 		}
 
@@ -223,7 +223,7 @@ public class SpellTicker {
 			if (nbt.hasKey("expiry"))
 				expiry = nbt.getInteger("expiry");
 			if (nbt.hasKey("module"))
-				module = Module.deserialize(nbt.getString("module"));
+				module = ModuleInstance.deserialize(nbt.getString("module"));
 		}
 	}
 }

--- a/src/main/java/com/teamwizardry/wizardry/common/core/SpellTicker.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/core/SpellTicker.java
@@ -72,7 +72,7 @@ public class SpellTicker {
 			long subtract = currentWorldTime - fromWorldTime;
 
 			if (subtract > delayedObject.getExpiry()) {
-				((IDelayedModule) delayedObject.getModule()).runDelayedEffect(delayedObject.getSpellData(), delayedObject.getSpellRing());
+				((IDelayedModule) delayedObject.getModule().getModuleClass()).runDelayedEffect(delayedObject.getSpellData(), delayedObject.getSpellRing());
 				delayed.remove();
 				change = true;
 			}

--- a/src/main/java/com/teamwizardry/wizardry/common/entity/projectile/EntitySpellProjectile.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/entity/projectile/EntitySpellProjectile.java
@@ -11,7 +11,7 @@ import com.teamwizardry.wizardry.Wizardry;
 import com.teamwizardry.wizardry.api.Constants;
 import com.teamwizardry.wizardry.api.spell.SpellData;
 import com.teamwizardry.wizardry.api.spell.SpellRing;
-import com.teamwizardry.wizardry.api.spell.module.ModuleShape;
+import com.teamwizardry.wizardry.api.spell.module.ModuleInstanceShape;
 import com.teamwizardry.wizardry.api.util.RandUtil;
 import com.teamwizardry.wizardry.api.util.RayTrace;
 import com.teamwizardry.wizardry.api.util.interp.InterpScale;
@@ -166,8 +166,8 @@ public class EntitySpellProjectile extends EntityMod {
 				@Override
 				@SideOnly(Side.CLIENT)
 				public void runIfClient() {
-					if (spellRing.getModule() instanceof ModuleShape)
-						if (((ModuleShape) spellRing.getModule()).runRenderOverrides(spellData, spellRing))
+					if (spellRing.getModule() instanceof ModuleInstanceShape)
+						if (((ModuleInstanceShape) spellRing.getModule()).runRenderOverrides(spellData, spellRing))
 							return;
 
 					ParticleBuilder glitter = new ParticleBuilder(10);

--- a/src/main/java/com/teamwizardry/wizardry/common/item/ItemBook.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/item/ItemBook.java
@@ -7,7 +7,7 @@ import com.teamwizardry.librarianlib.features.helpers.ItemNBTHelper;
 import com.teamwizardry.wizardry.Wizardry;
 import com.teamwizardry.wizardry.api.Constants;
 import com.teamwizardry.wizardry.api.spell.SpellUtils;
-import com.teamwizardry.wizardry.api.spell.module.Module;
+import com.teamwizardry.wizardry.api.spell.module.ModuleInstance;
 import com.teamwizardry.wizardry.client.gui.book.GuiBook;
 import com.teamwizardry.wizardry.common.advancement.IPickupAchievement;
 import com.teamwizardry.wizardry.common.advancement.ModAdvancements;
@@ -67,7 +67,7 @@ public class ItemBook extends ItemModBook implements IPickupAchievement {
 
 				if (event.getDwheel() > 0) {
 
-					List<List<Module>> spellModules = SpellUtils.deserializeModuleList(moduleList);
+					List<List<ModuleInstance>> spellModules = SpellUtils.deserializeModuleList(moduleList);
 					List<ItemStack> spellItems = SpellUtils.getSpellItems(spellModules);
 
 					int page = ItemNBTHelper.getInt(stack, "page", 0);

--- a/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectAntiGravityWell.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectAntiGravityWell.java
@@ -11,16 +11,10 @@ import com.teamwizardry.wizardry.api.Constants;
 import com.teamwizardry.wizardry.api.spell.ILingeringModule;
 import com.teamwizardry.wizardry.api.spell.SpellData;
 import com.teamwizardry.wizardry.api.spell.SpellRing;
-import com.teamwizardry.wizardry.api.spell.attribute.AttributeModifier;
-import com.teamwizardry.wizardry.api.spell.attribute.AttributeRange;
 import com.teamwizardry.wizardry.api.spell.attribute.AttributeRegistry;
-import com.teamwizardry.wizardry.api.spell.attribute.AttributeRegistry.Attribute;
 import com.teamwizardry.wizardry.api.spell.module.IModuleEffect;
 import com.teamwizardry.wizardry.api.spell.module.IModuleModifier;
-import com.teamwizardry.wizardry.api.spell.module.Module;
-import com.teamwizardry.wizardry.api.spell.module.ModuleEffect;
-import com.teamwizardry.wizardry.api.spell.module.ModuleModifier;
-import com.teamwizardry.wizardry.api.spell.module.ModuleType;
+import com.teamwizardry.wizardry.api.spell.module.ModuleInstanceEffect;
 import com.teamwizardry.wizardry.api.spell.module.RegisterModule;
 import com.teamwizardry.wizardry.api.util.RandUtil;
 import com.teamwizardry.wizardry.api.util.interp.InterpScale;
@@ -43,20 +37,11 @@ import javax.annotation.Nonnull;
 import static com.teamwizardry.wizardry.api.spell.SpellData.DefaultKeys.ENTITY_HIT;
 import static com.teamwizardry.wizardry.api.spell.SpellData.DefaultKeys.ORIGIN;
 
-import java.util.List;
-import java.util.Map;
-
 /**
  * Created by Demoniaque.
  */
 @RegisterModule
 public class ModuleEffectAntiGravityWell implements IModuleEffect, ILingeringModule {
-
-//	@Nonnull
-//	@Override
-//	public ModuleType getModuleType() {
-//		return ModuleType.EFFECT;
-//	}
 
 	@Nonnull
 	@Override
@@ -70,7 +55,7 @@ public class ModuleEffectAntiGravityWell implements IModuleEffect, ILingeringMod
 	}
 
 	@Override
-	public boolean run(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public boolean run(ModuleInstanceEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		World world = spell.world;
 		Vec3d position = spell.getTarget();
 
@@ -107,7 +92,7 @@ public class ModuleEffectAntiGravityWell implements IModuleEffect, ILingeringMod
 
 	@Override
 	@SideOnly(Side.CLIENT)
-	public void renderSpell(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public void renderSpell(ModuleInstanceEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		Vec3d position = spell.getData(ORIGIN);
 
 		if (position == null) return;

--- a/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectAntiGravityWell.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectAntiGravityWell.java
@@ -60,7 +60,7 @@ public class ModuleEffectAntiGravityWell implements IModuleEffect, ILingeringMod
 
 	@Nonnull
 	@Override
-	public String getID() {
+	public String getClassID() {
 		return "effect_anti_gravity_well";
 	}
 

--- a/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectAntiGravityWell.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectAntiGravityWell.java
@@ -11,7 +11,13 @@ import com.teamwizardry.wizardry.api.Constants;
 import com.teamwizardry.wizardry.api.spell.ILingeringModule;
 import com.teamwizardry.wizardry.api.spell.SpellData;
 import com.teamwizardry.wizardry.api.spell.SpellRing;
+import com.teamwizardry.wizardry.api.spell.attribute.AttributeModifier;
+import com.teamwizardry.wizardry.api.spell.attribute.AttributeRange;
 import com.teamwizardry.wizardry.api.spell.attribute.AttributeRegistry;
+import com.teamwizardry.wizardry.api.spell.attribute.AttributeRegistry.Attribute;
+import com.teamwizardry.wizardry.api.spell.module.IModuleEffect;
+import com.teamwizardry.wizardry.api.spell.module.IModuleModifier;
+import com.teamwizardry.wizardry.api.spell.module.Module;
 import com.teamwizardry.wizardry.api.spell.module.ModuleEffect;
 import com.teamwizardry.wizardry.api.spell.module.ModuleModifier;
 import com.teamwizardry.wizardry.api.spell.module.ModuleType;
@@ -37,17 +43,20 @@ import javax.annotation.Nonnull;
 import static com.teamwizardry.wizardry.api.spell.SpellData.DefaultKeys.ENTITY_HIT;
 import static com.teamwizardry.wizardry.api.spell.SpellData.DefaultKeys.ORIGIN;
 
+import java.util.List;
+import java.util.Map;
+
 /**
  * Created by Demoniaque.
  */
 @RegisterModule
-public class ModuleEffectAntiGravityWell extends ModuleEffect implements ILingeringModule {
+public class ModuleEffectAntiGravityWell implements IModuleEffect, ILingeringModule {
 
-	@Nonnull
-	@Override
-	public ModuleType getModuleType() {
-		return ModuleType.EFFECT;
-	}
+//	@Nonnull
+//	@Override
+//	public ModuleType getModuleType() {
+//		return ModuleType.EFFECT;
+//	}
 
 	@Nonnull
 	@Override
@@ -56,12 +65,12 @@ public class ModuleEffectAntiGravityWell extends ModuleEffect implements ILinger
 	}
 
 	@Override
-	public ModuleModifier[] applicableModifiers() {
-		return new ModuleModifier[]{new ModuleModifierIncreaseAOE(), new ModuleModifierIncreasePotency(), new ModuleModifierIncreaseDuration()};
+	public IModuleModifier[] applicableModifiers() {
+		return new IModuleModifier[]{new ModuleModifierIncreaseAOE(), new ModuleModifierIncreasePotency(), new ModuleModifierIncreaseDuration()};
 	}
 
 	@Override
-	public boolean run(@Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public boolean run(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		World world = spell.world;
 		Vec3d position = spell.getTarget();
 
@@ -98,13 +107,13 @@ public class ModuleEffectAntiGravityWell extends ModuleEffect implements ILinger
 
 	@Override
 	@SideOnly(Side.CLIENT)
-	public void renderSpell(@Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public void renderSpell(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		Vec3d position = spell.getData(ORIGIN);
 
 		if (position == null) return;
 
 		ParticleBuilder glitter = new ParticleBuilder(0);
-		glitter.setColorFunction(new InterpColorHSV(getPrimaryColor(), getSecondaryColor()));
+		glitter.setColorFunction(new InterpColorHSV(instance.getPrimaryColor(), instance.getSecondaryColor()));
 		ParticleSpawner.spawn(glitter, spell.world, new StaticInterp<>(position), 10, 10, (aFloat, particleBuilder) -> {
 			glitter.setScale((float) RandUtil.nextDouble(0.3, 1));
 			glitter.setAlphaFunction(new InterpFloatInOut(0.3f, (float) RandUtil.nextDouble(0.6, 1)));

--- a/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectBackup.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectBackup.java
@@ -12,10 +12,7 @@ import com.teamwizardry.wizardry.api.spell.SpellRing;
 import com.teamwizardry.wizardry.api.spell.attribute.AttributeRegistry;
 import com.teamwizardry.wizardry.api.spell.module.IModuleEffect;
 import com.teamwizardry.wizardry.api.spell.module.IModuleModifier;
-import com.teamwizardry.wizardry.api.spell.module.Module;
-import com.teamwizardry.wizardry.api.spell.module.ModuleEffect;
-import com.teamwizardry.wizardry.api.spell.module.ModuleModifier;
-import com.teamwizardry.wizardry.api.spell.module.ModuleType;
+import com.teamwizardry.wizardry.api.spell.module.ModuleInstanceEffect;
 import com.teamwizardry.wizardry.api.spell.module.RegisterModule;
 import com.teamwizardry.wizardry.api.util.RandUtil;
 import com.teamwizardry.wizardry.api.util.interp.InterpScale;
@@ -53,7 +50,7 @@ public class ModuleEffectBackup implements IModuleEffect {
 	}
 
 	@Override
-	public boolean run(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public boolean run(ModuleInstanceEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		World world = spell.world;
 		Vec3d targetPos = spell.getTarget();
 		EnumFacing facing = spell.getData(FACE_HIT);
@@ -79,7 +76,7 @@ public class ModuleEffectBackup implements IModuleEffect {
 
 	@Override
 	@SideOnly(Side.CLIENT)
-	public void renderSpell(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public void renderSpell(ModuleInstanceEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		World world = spell.world;
 		Vec3d position = spell.getTarget();
 

--- a/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectBackup.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectBackup.java
@@ -43,7 +43,7 @@ public class ModuleEffectBackup implements IModuleEffect {
 
 	@Nonnull
 	@Override
-	public String getID() {
+	public String getClassID() {
 		return "effect_backup";
 	}
 

--- a/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectBackup.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectBackup.java
@@ -10,8 +10,12 @@ import com.teamwizardry.wizardry.api.Constants;
 import com.teamwizardry.wizardry.api.spell.SpellData;
 import com.teamwizardry.wizardry.api.spell.SpellRing;
 import com.teamwizardry.wizardry.api.spell.attribute.AttributeRegistry;
+import com.teamwizardry.wizardry.api.spell.module.IModuleEffect;
+import com.teamwizardry.wizardry.api.spell.module.IModuleModifier;
+import com.teamwizardry.wizardry.api.spell.module.Module;
 import com.teamwizardry.wizardry.api.spell.module.ModuleEffect;
 import com.teamwizardry.wizardry.api.spell.module.ModuleModifier;
+import com.teamwizardry.wizardry.api.spell.module.ModuleType;
 import com.teamwizardry.wizardry.api.spell.module.RegisterModule;
 import com.teamwizardry.wizardry.api.util.RandUtil;
 import com.teamwizardry.wizardry.api.util.interp.InterpScale;
@@ -35,7 +39,7 @@ import static com.teamwizardry.wizardry.api.spell.SpellData.DefaultKeys.FACE_HIT
  * Created by Demoniaque.
  */
 @RegisterModule
-public class ModuleEffectBackup extends ModuleEffect {
+public class ModuleEffectBackup implements IModuleEffect {
 
 	@Nonnull
 	@Override
@@ -44,12 +48,12 @@ public class ModuleEffectBackup extends ModuleEffect {
 	}
 
 	@Override
-	public ModuleModifier[] applicableModifiers() {
-		return new ModuleModifier[]{new ModuleModifierIncreaseDuration()};
+	public IModuleModifier[] applicableModifiers() {
+		return new IModuleModifier[]{new ModuleModifierIncreaseDuration()};
 	}
 
 	@Override
-	public boolean run(@Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public boolean run(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		World world = spell.world;
 		Vec3d targetPos = spell.getTarget();
 		EnumFacing facing = spell.getData(FACE_HIT);
@@ -75,7 +79,7 @@ public class ModuleEffectBackup extends ModuleEffect {
 
 	@Override
 	@SideOnly(Side.CLIENT)
-	public void renderSpell(@Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public void renderSpell(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		World world = spell.world;
 		Vec3d position = spell.getTarget();
 
@@ -83,7 +87,7 @@ public class ModuleEffectBackup extends ModuleEffect {
 
 		ParticleBuilder glitter = new ParticleBuilder(1);
 		glitter.setAlphaFunction(new InterpFloatInOut(0.0f, 0.1f));
-		glitter.setColorFunction(new InterpColorHSV(getPrimaryColor(), getSecondaryColor()));
+		glitter.setColorFunction(new InterpColorHSV(instance.getPrimaryColor(), instance.getSecondaryColor()));
 		glitter.enableMotionCalculation();
 		glitter.setScaleFunction(new InterpScale(1, 0));
 		glitter.setAcceleration(new Vec3d(0, -0.05, 0));

--- a/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectBreak.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectBreak.java
@@ -5,9 +5,7 @@ import com.teamwizardry.wizardry.api.spell.SpellRing;
 import com.teamwizardry.wizardry.api.spell.attribute.AttributeRegistry;
 import com.teamwizardry.wizardry.api.spell.module.IModuleEffect;
 import com.teamwizardry.wizardry.api.spell.module.IModuleModifier;
-import com.teamwizardry.wizardry.api.spell.module.Module;
-import com.teamwizardry.wizardry.api.spell.module.ModuleEffect;
-import com.teamwizardry.wizardry.api.spell.module.ModuleModifier;
+import com.teamwizardry.wizardry.api.spell.module.ModuleInstanceEffect;
 import com.teamwizardry.wizardry.api.spell.module.ModuleRegistry;
 import com.teamwizardry.wizardry.api.spell.module.RegisterModule;
 import com.teamwizardry.wizardry.api.util.BlockUtils;
@@ -52,7 +50,7 @@ public class ModuleEffectBreak implements IModuleEffect {
 	}
 
 	@Override
-	public boolean run(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public boolean run(ModuleInstanceEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		World world = spell.world;
 		BlockPos targetPos = spell.getData(BLOCK_HIT);
 		EnumFacing facing = spell.getData(FACE_HIT);
@@ -88,7 +86,7 @@ public class ModuleEffectBreak implements IModuleEffect {
 
 	@Override
 	@SideOnly(Side.CLIENT)
-	public void renderSpell(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public void renderSpell(ModuleInstanceEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		World world = spell.world;
 		Vec3d position = spell.getTarget();
 
@@ -99,7 +97,7 @@ public class ModuleEffectBreak implements IModuleEffect {
 
 	@NotNull
 	@Override
-	public SpellData renderVisualization(ModuleEffect instance, @Nonnull SpellData data, @Nonnull SpellRing ring, @Nonnull SpellData previousData) {
+	public SpellData renderVisualization(ModuleInstanceEffect instance, @Nonnull SpellData data, @Nonnull SpellRing ring, @Nonnull SpellData previousData) {
 		if (ring.getParentRing() != null
 				&& ring.getParentRing().getModule() != null
 				&& ring.getParentRing().getModule() == ModuleRegistry.INSTANCE.getModule("event_collide_entity"))

--- a/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectBreak.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectBreak.java
@@ -42,7 +42,7 @@ public class ModuleEffectBreak implements IModuleEffect {
 
 	@Nonnull
 	@Override
-	public String getID() {
+	public String getClassID() {
 		return "effect_break";
 	}
 

--- a/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectBreak.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectBreak.java
@@ -3,6 +3,9 @@ package com.teamwizardry.wizardry.common.module.effects;
 import com.teamwizardry.wizardry.api.spell.SpellData;
 import com.teamwizardry.wizardry.api.spell.SpellRing;
 import com.teamwizardry.wizardry.api.spell.attribute.AttributeRegistry;
+import com.teamwizardry.wizardry.api.spell.module.IModuleEffect;
+import com.teamwizardry.wizardry.api.spell.module.IModuleModifier;
+import com.teamwizardry.wizardry.api.spell.module.Module;
 import com.teamwizardry.wizardry.api.spell.module.ModuleEffect;
 import com.teamwizardry.wizardry.api.spell.module.ModuleModifier;
 import com.teamwizardry.wizardry.api.spell.module.ModuleRegistry;
@@ -35,7 +38,7 @@ import static com.teamwizardry.wizardry.api.spell.SpellData.DefaultKeys.FACE_HIT
  * Created by Demoniaque.
  */
 @RegisterModule
-public class ModuleEffectBreak extends ModuleEffect {
+public class ModuleEffectBreak implements IModuleEffect {
 
 	@Nonnull
 	@Override
@@ -44,12 +47,12 @@ public class ModuleEffectBreak extends ModuleEffect {
 	}
 
 	@Override
-	public ModuleModifier[] applicableModifiers() {
-		return new ModuleModifier[]{new ModuleModifierIncreaseAOE(), new ModuleModifierIncreasePotency()};
+	public IModuleModifier[] applicableModifiers() {
+		return new IModuleModifier[]{new ModuleModifierIncreaseAOE(), new ModuleModifierIncreasePotency()};
 	}
 
 	@Override
-	public boolean run(@Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public boolean run(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		World world = spell.world;
 		BlockPos targetPos = spell.getData(BLOCK_HIT);
 		EnumFacing facing = spell.getData(FACE_HIT);
@@ -85,18 +88,18 @@ public class ModuleEffectBreak extends ModuleEffect {
 
 	@Override
 	@SideOnly(Side.CLIENT)
-	public void renderSpell(@Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public void renderSpell(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		World world = spell.world;
 		Vec3d position = spell.getTarget();
 
 		if (position == null) return;
 
-		LibParticles.EXPLODE(world, position, getPrimaryColor(), getSecondaryColor(), 0.2, 0.3, 20, 40, 10, true);
+		LibParticles.EXPLODE(world, position, instance.getPrimaryColor(), instance.getSecondaryColor(), 0.2, 0.3, 20, 40, 10, true);
 	}
 
 	@NotNull
 	@Override
-	public SpellData renderVisualization(@Nonnull SpellData data, @Nonnull SpellRing ring, @Nonnull SpellData previousData) {
+	public SpellData renderVisualization(ModuleEffect instance, @Nonnull SpellData data, @Nonnull SpellRing ring, @Nonnull SpellData previousData) {
 		if (ring.getParentRing() != null
 				&& ring.getParentRing().getModule() != null
 				&& ring.getParentRing().getModule() == ModuleRegistry.INSTANCE.getModule("event_collide_entity"))
@@ -127,9 +130,9 @@ public class ModuleEffectBreak extends ModuleEffect {
 			BlockPos.MutableBlockPos mutable = new BlockPos.MutableBlockPos(pos);
 			for (EnumFacing face : EnumFacing.VALUES) {
 					mutable.move(face);
-					IBlockState adjStat = getCachableBlockstate(data.world, mutable, previousData);
+					IBlockState adjStat = instance.getCachableBlockstate(data.world, mutable, previousData);
 					if (adjStat.getBlock() != state.getBlock() || !blocks.contains(mutable)) {
-						drawFaceOutline(mutable, face.getOpposite());
+						instance.drawFaceOutline(mutable, face.getOpposite());
 				}
 				mutable.move(face.getOpposite());
 			}

--- a/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectBurn.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectBurn.java
@@ -40,7 +40,7 @@ public class ModuleEffectBurn implements IModuleEffect {
 
 	@Nonnull
 	@Override
-	public String getID() {
+	public String getClassID() {
 		return "effect_burn";
 	}
 

--- a/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectBurn.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectBurn.java
@@ -1,10 +1,17 @@
 package com.teamwizardry.wizardry.common.module.effects;
 
+import static com.teamwizardry.wizardry.api.spell.SpellData.DefaultKeys.FACE_HIT;
+
+import java.awt.Color;
+
+import javax.annotation.Nonnull;
+
 import com.teamwizardry.wizardry.api.spell.SpellData;
 import com.teamwizardry.wizardry.api.spell.SpellRing;
 import com.teamwizardry.wizardry.api.spell.attribute.AttributeRegistry;
+import com.teamwizardry.wizardry.api.spell.module.IModuleEffect;
+import com.teamwizardry.wizardry.api.spell.module.IModuleModifier;
 import com.teamwizardry.wizardry.api.spell.module.ModuleEffect;
-import com.teamwizardry.wizardry.api.spell.module.ModuleModifier;
 import com.teamwizardry.wizardry.api.spell.module.RegisterModule;
 import com.teamwizardry.wizardry.api.util.BlockUtils;
 import com.teamwizardry.wizardry.api.util.RandUtil;
@@ -12,6 +19,7 @@ import com.teamwizardry.wizardry.client.fx.LibParticles;
 import com.teamwizardry.wizardry.common.module.modifiers.ModuleModifierIncreaseAOE;
 import com.teamwizardry.wizardry.common.module.modifiers.ModuleModifierIncreaseDuration;
 import com.teamwizardry.wizardry.init.ModSounds;
+
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
@@ -24,16 +32,11 @@ import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-import javax.annotation.Nonnull;
-import java.awt.*;
-
-import static com.teamwizardry.wizardry.api.spell.SpellData.DefaultKeys.FACE_HIT;
-
 /**
  * Created by Demoniaque.
  */
 @RegisterModule
-public class ModuleEffectBurn extends ModuleEffect {
+public class ModuleEffectBurn implements IModuleEffect {
 
 	@Nonnull
 	@Override
@@ -42,12 +45,12 @@ public class ModuleEffectBurn extends ModuleEffect {
 	}
 
 	@Override
-	public ModuleModifier[] applicableModifiers() {
-		return new ModuleModifier[]{new ModuleModifierIncreaseAOE(), new ModuleModifierIncreaseDuration()};
+	public IModuleModifier[] applicableModifiers() {
+		return new IModuleModifier[]{new ModuleModifierIncreaseAOE(), new ModuleModifierIncreaseDuration()};
 	}
 
 	@Override
-	public boolean run(@Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public boolean run(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		World world = spell.world;
 		Entity targetEntity = spell.getVictim();
 		BlockPos targetPos = spell.getTargetPos();
@@ -87,14 +90,14 @@ public class ModuleEffectBurn extends ModuleEffect {
 
 	@Override
 	@SideOnly(Side.CLIENT)
-	public void renderSpell(@Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public void renderSpell(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		World world = spell.world;
 		Vec3d position = spell.getTarget();
 
 		if (position == null) return;
 
-		Color color = getPrimaryColor();
-		if (RandUtil.nextBoolean()) color = getSecondaryColor();
+		Color color = instance.getPrimaryColor();
+		if (RandUtil.nextBoolean()) color = instance.getSecondaryColor();
 
 		LibParticles.EFFECT_BURN(world, position, color);
 	}

--- a/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectBurn.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectBurn.java
@@ -11,7 +11,7 @@ import com.teamwizardry.wizardry.api.spell.SpellRing;
 import com.teamwizardry.wizardry.api.spell.attribute.AttributeRegistry;
 import com.teamwizardry.wizardry.api.spell.module.IModuleEffect;
 import com.teamwizardry.wizardry.api.spell.module.IModuleModifier;
-import com.teamwizardry.wizardry.api.spell.module.ModuleEffect;
+import com.teamwizardry.wizardry.api.spell.module.ModuleInstanceEffect;
 import com.teamwizardry.wizardry.api.spell.module.RegisterModule;
 import com.teamwizardry.wizardry.api.util.BlockUtils;
 import com.teamwizardry.wizardry.api.util.RandUtil;
@@ -50,7 +50,7 @@ public class ModuleEffectBurn implements IModuleEffect {
 	}
 
 	@Override
-	public boolean run(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public boolean run(ModuleInstanceEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		World world = spell.world;
 		Entity targetEntity = spell.getVictim();
 		BlockPos targetPos = spell.getTargetPos();
@@ -90,7 +90,7 @@ public class ModuleEffectBurn implements IModuleEffect {
 
 	@Override
 	@SideOnly(Side.CLIENT)
-	public void renderSpell(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public void renderSpell(ModuleInstanceEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		World world = spell.world;
 		Vec3d position = spell.getTarget();
 

--- a/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectCrasherFall.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectCrasherFall.java
@@ -1,15 +1,19 @@
 package com.teamwizardry.wizardry.common.module.effects;
 
+import javax.annotation.Nonnull;
+
 import com.teamwizardry.wizardry.api.spell.SpellData;
 import com.teamwizardry.wizardry.api.spell.SpellRing;
 import com.teamwizardry.wizardry.api.spell.attribute.AttributeRegistry;
+import com.teamwizardry.wizardry.api.spell.module.IModuleEffect;
+import com.teamwizardry.wizardry.api.spell.module.IModuleModifier;
 import com.teamwizardry.wizardry.api.spell.module.ModuleEffect;
-import com.teamwizardry.wizardry.api.spell.module.ModuleModifier;
 import com.teamwizardry.wizardry.api.spell.module.RegisterModule;
 import com.teamwizardry.wizardry.client.fx.LibParticles;
 import com.teamwizardry.wizardry.common.module.modifiers.ModuleModifierIncreaseDuration;
 import com.teamwizardry.wizardry.common.module.modifiers.ModuleModifierIncreaseRange;
 import com.teamwizardry.wizardry.init.ModPotions;
+
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.potion.PotionEffect;
@@ -18,13 +22,11 @@ import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-import javax.annotation.Nonnull;
-
 /**
  * Created by Demoniaque.
  */
 @RegisterModule
-public class ModuleEffectCrasherFall extends ModuleEffect {
+public class ModuleEffectCrasherFall implements IModuleEffect {
 
 	@Nonnull
 	@Override
@@ -33,12 +35,12 @@ public class ModuleEffectCrasherFall extends ModuleEffect {
 	}
 
 	@Override
-	public ModuleModifier[] applicableModifiers() {
-		return new ModuleModifier[]{new ModuleModifierIncreaseRange(), new ModuleModifierIncreaseDuration()};
+	public IModuleModifier[] applicableModifiers() {
+		return new IModuleModifier[]{new ModuleModifierIncreaseRange(), new ModuleModifierIncreaseDuration()};
 	}
 
 	@Override
-	public boolean run(@Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public boolean run(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		Entity targetEntity = spell.getVictim();
 
 		if (targetEntity instanceof EntityLivingBase) {
@@ -53,12 +55,12 @@ public class ModuleEffectCrasherFall extends ModuleEffect {
 
 	@Override
 	@SideOnly(Side.CLIENT)
-	public void renderSpell(@Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public void renderSpell(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		World world = spell.world;
 		Vec3d position = spell.getTarget();
 
 		if (position == null) return;
 
-		LibParticles.EFFECT_REGENERATE(world, position, getPrimaryColor());
+		LibParticles.EFFECT_REGENERATE(world, position, instance.getPrimaryColor());
 	}
 }

--- a/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectCrasherFall.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectCrasherFall.java
@@ -7,7 +7,7 @@ import com.teamwizardry.wizardry.api.spell.SpellRing;
 import com.teamwizardry.wizardry.api.spell.attribute.AttributeRegistry;
 import com.teamwizardry.wizardry.api.spell.module.IModuleEffect;
 import com.teamwizardry.wizardry.api.spell.module.IModuleModifier;
-import com.teamwizardry.wizardry.api.spell.module.ModuleEffect;
+import com.teamwizardry.wizardry.api.spell.module.ModuleInstanceEffect;
 import com.teamwizardry.wizardry.api.spell.module.RegisterModule;
 import com.teamwizardry.wizardry.client.fx.LibParticles;
 import com.teamwizardry.wizardry.common.module.modifiers.ModuleModifierIncreaseDuration;
@@ -40,7 +40,7 @@ public class ModuleEffectCrasherFall implements IModuleEffect {
 	}
 
 	@Override
-	public boolean run(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public boolean run(ModuleInstanceEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		Entity targetEntity = spell.getVictim();
 
 		if (targetEntity instanceof EntityLivingBase) {
@@ -55,7 +55,7 @@ public class ModuleEffectCrasherFall implements IModuleEffect {
 
 	@Override
 	@SideOnly(Side.CLIENT)
-	public void renderSpell(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public void renderSpell(ModuleInstanceEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		World world = spell.world;
 		Vec3d position = spell.getTarget();
 

--- a/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectCrasherFall.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectCrasherFall.java
@@ -30,7 +30,7 @@ public class ModuleEffectCrasherFall implements IModuleEffect {
 
 	@Nonnull
 	@Override
-	public String getID() {
+	public String getClassID() {
 		return "effect_crasher_fall";
 	}
 

--- a/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectDisarm.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectDisarm.java
@@ -36,7 +36,7 @@ public class ModuleEffectDisarm implements IModuleEffect {
 
 	@Nonnull
 	@Override
-	public String getID() {
+	public String getClassID() {
 		return "effect_disarm";
 	}
 

--- a/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectDisarm.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectDisarm.java
@@ -3,6 +3,8 @@ package com.teamwizardry.wizardry.common.module.effects;
 import com.teamwizardry.librarianlib.features.methodhandles.MethodHandleHelper;
 import com.teamwizardry.wizardry.api.spell.SpellData;
 import com.teamwizardry.wizardry.api.spell.SpellRing;
+import com.teamwizardry.wizardry.api.spell.module.IModuleEffect;
+import com.teamwizardry.wizardry.api.spell.module.Module;
 import com.teamwizardry.wizardry.api.spell.module.ModuleEffect;
 import com.teamwizardry.wizardry.api.spell.module.RegisterModule;
 import com.teamwizardry.wizardry.api.util.RandUtil;
@@ -28,7 +30,7 @@ import javax.annotation.Nonnull;
  * Created by Demoniaque.
  */
 @RegisterModule
-public class ModuleEffectDisarm extends ModuleEffect {
+public class ModuleEffectDisarm implements IModuleEffect {
 
 	private Function1<EntityLiving, Object> inventoryHandsDropChances = MethodHandleHelper.wrapperForGetter(EntityLiving.class, "inventoryHandsDropChances", "field_184655_bs", "bs");
 
@@ -39,7 +41,7 @@ public class ModuleEffectDisarm extends ModuleEffect {
 	}
 
 	@Override
-	public boolean run(@Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public boolean run(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		Entity targetEntity = spell.getVictim();
 
 		if (targetEntity instanceof EntityLivingBase) {
@@ -97,12 +99,12 @@ public class ModuleEffectDisarm extends ModuleEffect {
 
 	@Override
 	@SideOnly(Side.CLIENT)
-	public void renderSpell(@Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public void renderSpell(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		World world = spell.world;
 		Vec3d position = spell.getTarget();
 
 		if (position == null) return;
 
-		LibParticles.EFFECT_REGENERATE(world, position, getPrimaryColor());
+		LibParticles.EFFECT_REGENERATE(world, position, instance.getPrimaryColor());
 	}
 }

--- a/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectDisarm.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectDisarm.java
@@ -4,8 +4,7 @@ import com.teamwizardry.librarianlib.features.methodhandles.MethodHandleHelper;
 import com.teamwizardry.wizardry.api.spell.SpellData;
 import com.teamwizardry.wizardry.api.spell.SpellRing;
 import com.teamwizardry.wizardry.api.spell.module.IModuleEffect;
-import com.teamwizardry.wizardry.api.spell.module.Module;
-import com.teamwizardry.wizardry.api.spell.module.ModuleEffect;
+import com.teamwizardry.wizardry.api.spell.module.ModuleInstanceEffect;
 import com.teamwizardry.wizardry.api.spell.module.RegisterModule;
 import com.teamwizardry.wizardry.api.util.RandUtil;
 import com.teamwizardry.wizardry.client.fx.LibParticles;
@@ -41,7 +40,7 @@ public class ModuleEffectDisarm implements IModuleEffect {
 	}
 
 	@Override
-	public boolean run(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public boolean run(ModuleInstanceEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		Entity targetEntity = spell.getVictim();
 
 		if (targetEntity instanceof EntityLivingBase) {
@@ -99,7 +98,7 @@ public class ModuleEffectDisarm implements IModuleEffect {
 
 	@Override
 	@SideOnly(Side.CLIENT)
-	public void renderSpell(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public void renderSpell(ModuleInstanceEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		World world = spell.world;
 		Vec3d position = spell.getTarget();
 

--- a/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectFrost.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectFrost.java
@@ -9,8 +9,10 @@ import com.teamwizardry.wizardry.api.Constants;
 import com.teamwizardry.wizardry.api.spell.SpellData;
 import com.teamwizardry.wizardry.api.spell.SpellRing;
 import com.teamwizardry.wizardry.api.spell.attribute.AttributeRegistry;
+import com.teamwizardry.wizardry.api.spell.module.IModuleEffect;
+import com.teamwizardry.wizardry.api.spell.module.IModuleModifier;
+import com.teamwizardry.wizardry.api.spell.module.Module;
 import com.teamwizardry.wizardry.api.spell.module.ModuleEffect;
-import com.teamwizardry.wizardry.api.spell.module.ModuleModifier;
 import com.teamwizardry.wizardry.api.spell.module.RegisterModule;
 import com.teamwizardry.wizardry.api.util.BlockUtils;
 import com.teamwizardry.wizardry.api.util.RandUtil;
@@ -43,7 +45,7 @@ import javax.annotation.Nonnull;
  * Created by Demoniaque.
  */
 @RegisterModule
-public class ModuleEffectFrost extends ModuleEffect {
+public class ModuleEffectFrost implements IModuleEffect {
 
 	@Nonnull
 	@Override
@@ -52,12 +54,12 @@ public class ModuleEffectFrost extends ModuleEffect {
 	}
 
 	@Override
-	public ModuleModifier[] applicableModifiers() {
-		return new ModuleModifier[]{new ModuleModifierIncreaseAOE(), new ModuleModifierIncreaseDuration()};
+	public IModuleModifier[] applicableModifiers() {
+		return new IModuleModifier[]{new ModuleModifierIncreaseAOE(), new ModuleModifierIncreaseDuration()};
 	}
 
 	@Override
-	public boolean run(@Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public boolean run(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		World world = spell.world;
 		Entity targetEntity = spell.getVictim();
 		BlockPos targetPos = spell.getTargetPos();
@@ -107,7 +109,7 @@ public class ModuleEffectFrost extends ModuleEffect {
 
 	@Override
 	@SideOnly(Side.CLIENT)
-	public void renderSpell(@Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public void renderSpell(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		World world = spell.world;
 		Vec3d position = spell.getTarget();
 

--- a/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectFrost.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectFrost.java
@@ -49,7 +49,7 @@ public class ModuleEffectFrost implements IModuleEffect {
 
 	@Nonnull
 	@Override
-	public String getID() {
+	public String getClassID() {
 		return "effect_frost";
 	}
 

--- a/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectFrost.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectFrost.java
@@ -11,8 +11,7 @@ import com.teamwizardry.wizardry.api.spell.SpellRing;
 import com.teamwizardry.wizardry.api.spell.attribute.AttributeRegistry;
 import com.teamwizardry.wizardry.api.spell.module.IModuleEffect;
 import com.teamwizardry.wizardry.api.spell.module.IModuleModifier;
-import com.teamwizardry.wizardry.api.spell.module.Module;
-import com.teamwizardry.wizardry.api.spell.module.ModuleEffect;
+import com.teamwizardry.wizardry.api.spell.module.ModuleInstanceEffect;
 import com.teamwizardry.wizardry.api.spell.module.RegisterModule;
 import com.teamwizardry.wizardry.api.util.BlockUtils;
 import com.teamwizardry.wizardry.api.util.RandUtil;
@@ -59,7 +58,7 @@ public class ModuleEffectFrost implements IModuleEffect {
 	}
 
 	@Override
-	public boolean run(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public boolean run(ModuleInstanceEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		World world = spell.world;
 		Entity targetEntity = spell.getVictim();
 		BlockPos targetPos = spell.getTargetPos();
@@ -109,7 +108,7 @@ public class ModuleEffectFrost implements IModuleEffect {
 
 	@Override
 	@SideOnly(Side.CLIENT)
-	public void renderSpell(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public void renderSpell(ModuleInstanceEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		World world = spell.world;
 		Vec3d position = spell.getTarget();
 

--- a/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectGravityWell.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectGravityWell.java
@@ -45,7 +45,7 @@ public class ModuleEffectGravityWell implements IModuleEffect, ILingeringModule 
 
 	@Nonnull
 	@Override
-	public String getID() {
+	public String getClassID() {
 		return "effect_gravity_well";
 	}
 

--- a/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectGravityWell.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectGravityWell.java
@@ -14,8 +14,7 @@ import com.teamwizardry.wizardry.api.spell.SpellRing;
 import com.teamwizardry.wizardry.api.spell.attribute.AttributeRegistry;
 import com.teamwizardry.wizardry.api.spell.module.IModuleEffect;
 import com.teamwizardry.wizardry.api.spell.module.IModuleModifier;
-import com.teamwizardry.wizardry.api.spell.module.Module;
-import com.teamwizardry.wizardry.api.spell.module.ModuleEffect;
+import com.teamwizardry.wizardry.api.spell.module.ModuleInstanceEffect;
 import com.teamwizardry.wizardry.api.spell.module.RegisterModule;
 import com.teamwizardry.wizardry.api.util.RandUtil;
 import com.teamwizardry.wizardry.api.util.interp.InterpScale;
@@ -55,7 +54,7 @@ public class ModuleEffectGravityWell implements IModuleEffect, ILingeringModule 
 	}
 
 	@Override
-	public boolean run(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public boolean run(ModuleInstanceEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		World world = spell.world;
 		Vec3d position = spell.getTarget();
 
@@ -92,7 +91,7 @@ public class ModuleEffectGravityWell implements IModuleEffect, ILingeringModule 
 
 	@Override
 	@SideOnly(Side.CLIENT)
-	public void renderSpell(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public void renderSpell(ModuleInstanceEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		Vec3d position = spell.getTarget();
 
 		if (position == null) return;

--- a/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectGravityWell.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectGravityWell.java
@@ -12,8 +12,10 @@ import com.teamwizardry.wizardry.api.spell.ILingeringModule;
 import com.teamwizardry.wizardry.api.spell.SpellData;
 import com.teamwizardry.wizardry.api.spell.SpellRing;
 import com.teamwizardry.wizardry.api.spell.attribute.AttributeRegistry;
+import com.teamwizardry.wizardry.api.spell.module.IModuleEffect;
+import com.teamwizardry.wizardry.api.spell.module.IModuleModifier;
+import com.teamwizardry.wizardry.api.spell.module.Module;
 import com.teamwizardry.wizardry.api.spell.module.ModuleEffect;
-import com.teamwizardry.wizardry.api.spell.module.ModuleModifier;
 import com.teamwizardry.wizardry.api.spell.module.RegisterModule;
 import com.teamwizardry.wizardry.api.util.RandUtil;
 import com.teamwizardry.wizardry.api.util.interp.InterpScale;
@@ -39,7 +41,7 @@ import static com.teamwizardry.wizardry.api.spell.SpellData.DefaultKeys.ENTITY_H
  * Created by Demoniaque.
  */
 @RegisterModule
-public class ModuleEffectGravityWell extends ModuleEffect implements ILingeringModule {
+public class ModuleEffectGravityWell implements IModuleEffect, ILingeringModule {
 
 	@Nonnull
 	@Override
@@ -48,12 +50,12 @@ public class ModuleEffectGravityWell extends ModuleEffect implements ILingeringM
 	}
 
 	@Override
-	public ModuleModifier[] applicableModifiers() {
-		return new ModuleModifier[]{new ModuleModifierIncreaseAOE(), new ModuleModifierIncreasePotency(), new ModuleModifierIncreaseDuration()};
+	public IModuleModifier[] applicableModifiers() {
+		return new IModuleModifier[]{new ModuleModifierIncreaseAOE(), new ModuleModifierIncreasePotency(), new ModuleModifierIncreaseDuration()};
 	}
 
 	@Override
-	public boolean run(@Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public boolean run(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		World world = spell.world;
 		Vec3d position = spell.getTarget();
 
@@ -90,13 +92,13 @@ public class ModuleEffectGravityWell extends ModuleEffect implements ILingeringM
 
 	@Override
 	@SideOnly(Side.CLIENT)
-	public void renderSpell(@Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public void renderSpell(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		Vec3d position = spell.getTarget();
 
 		if (position == null) return;
 
 		ParticleBuilder glitter = new ParticleBuilder(0);
-		glitter.setColorFunction(new InterpColorHSV(getPrimaryColor(), getSecondaryColor()));
+		glitter.setColorFunction(new InterpColorHSV(instance.getPrimaryColor(), instance.getSecondaryColor()));
 		ParticleSpawner.spawn(glitter, spell.world, new StaticInterp<>(position), 10, 10, (aFloat, particleBuilder) -> {
 			glitter.setScale((float) RandUtil.nextDouble(0.3, 1));
 			glitter.setAlphaFunction(new InterpFloatInOut(0.3f, (float) RandUtil.nextDouble(0.6, 1)));

--- a/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectLeap.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectLeap.java
@@ -7,8 +7,7 @@ import com.teamwizardry.wizardry.api.spell.SpellRing;
 import com.teamwizardry.wizardry.api.spell.attribute.AttributeRegistry;
 import com.teamwizardry.wizardry.api.spell.module.IModuleEffect;
 import com.teamwizardry.wizardry.api.spell.module.IModuleModifier;
-import com.teamwizardry.wizardry.api.spell.module.Module;
-import com.teamwizardry.wizardry.api.spell.module.ModuleEffect;
+import com.teamwizardry.wizardry.api.spell.module.ModuleInstanceEffect;
 import com.teamwizardry.wizardry.api.spell.module.RegisterModule;
 import com.teamwizardry.wizardry.client.fx.LibParticles;
 import com.teamwizardry.wizardry.common.module.modifiers.ModuleModifierIncreasePotency;
@@ -78,7 +77,7 @@ public class ModuleEffectLeap implements IModuleEffect, IOverrideCooldown {
 	}
 
 	@Override
-	public boolean run(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public boolean run(ModuleInstanceEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		Vec3d lookVec = spell.getData(LOOK);
 		Entity target = spell.getVictim();
 
@@ -117,7 +116,7 @@ public class ModuleEffectLeap implements IModuleEffect, IOverrideCooldown {
 
 	@Override
 	@SideOnly(Side.CLIENT)
-	public void renderSpell(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public void renderSpell(ModuleInstanceEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		Vec3d position = spell.getTarget();
 		Entity entityHit = spell.getVictim();
 

--- a/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectLeap.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectLeap.java
@@ -5,8 +5,10 @@ import com.teamwizardry.wizardry.api.spell.IOverrideCooldown;
 import com.teamwizardry.wizardry.api.spell.SpellData;
 import com.teamwizardry.wizardry.api.spell.SpellRing;
 import com.teamwizardry.wizardry.api.spell.attribute.AttributeRegistry;
+import com.teamwizardry.wizardry.api.spell.module.IModuleEffect;
+import com.teamwizardry.wizardry.api.spell.module.IModuleModifier;
+import com.teamwizardry.wizardry.api.spell.module.Module;
 import com.teamwizardry.wizardry.api.spell.module.ModuleEffect;
-import com.teamwizardry.wizardry.api.spell.module.ModuleModifier;
 import com.teamwizardry.wizardry.api.spell.module.RegisterModule;
 import com.teamwizardry.wizardry.client.fx.LibParticles;
 import com.teamwizardry.wizardry.common.module.modifiers.ModuleModifierIncreasePotency;
@@ -33,7 +35,7 @@ import static com.teamwizardry.wizardry.api.spell.SpellData.DefaultKeys.LOOK;
  * Created by Demoniaque.
  */
 @RegisterModule
-public class ModuleEffectLeap extends ModuleEffect implements IOverrideCooldown {
+public class ModuleEffectLeap implements IModuleEffect, IOverrideCooldown {
 
 	@Nonnull
 	@Override
@@ -42,8 +44,8 @@ public class ModuleEffectLeap extends ModuleEffect implements IOverrideCooldown 
 	}
 
 	@Override
-	public ModuleModifier[] applicableModifiers() {
-		return new ModuleModifier[]{new ModuleModifierIncreasePotency()};
+	public IModuleModifier[] applicableModifiers() {
+		return new IModuleModifier[]{new ModuleModifierIncreasePotency()};
 	}
 
 	@Override
@@ -76,7 +78,7 @@ public class ModuleEffectLeap extends ModuleEffect implements IOverrideCooldown 
 	}
 
 	@Override
-	public boolean run(@Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public boolean run(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		Vec3d lookVec = spell.getData(LOOK);
 		Entity target = spell.getVictim();
 
@@ -115,7 +117,7 @@ public class ModuleEffectLeap extends ModuleEffect implements IOverrideCooldown 
 
 	@Override
 	@SideOnly(Side.CLIENT)
-	public void renderSpell(@Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public void renderSpell(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		Vec3d position = spell.getTarget();
 		Entity entityHit = spell.getVictim();
 
@@ -125,7 +127,7 @@ public class ModuleEffectLeap extends ModuleEffect implements IOverrideCooldown 
 		if (!entityHit.hasNoGravity()) {
 			Vec3d normal = new Vec3d(entityHit.motionX, entityHit.motionY, entityHit.motionZ).normalize().scale(1 / 2.0);
 
-			LibParticles.AIR_THROTTLE(spell.world, position, normal, getPrimaryColor(), getSecondaryColor(), 0.5);
+			LibParticles.AIR_THROTTLE(spell.world, position, normal, instance.getPrimaryColor(), instance.getSecondaryColor(), 0.5);
 
 		}
 	}

--- a/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectLeap.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectLeap.java
@@ -39,7 +39,7 @@ public class ModuleEffectLeap implements IModuleEffect, IOverrideCooldown {
 
 	@Nonnull
 	@Override
-	public String getID() {
+	public String getClassID() {
 		return "effect_leap";
 	}
 

--- a/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectLeech.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectLeech.java
@@ -10,8 +10,10 @@ import com.teamwizardry.wizardry.api.capability.mana.CapManager;
 import com.teamwizardry.wizardry.api.spell.SpellData;
 import com.teamwizardry.wizardry.api.spell.SpellRing;
 import com.teamwizardry.wizardry.api.spell.attribute.AttributeRegistry;
+import com.teamwizardry.wizardry.api.spell.module.IModuleEffect;
+import com.teamwizardry.wizardry.api.spell.module.IModuleModifier;
+import com.teamwizardry.wizardry.api.spell.module.Module;
 import com.teamwizardry.wizardry.api.spell.module.ModuleEffect;
-import com.teamwizardry.wizardry.api.spell.module.ModuleModifier;
 import com.teamwizardry.wizardry.api.spell.module.RegisterModule;
 import com.teamwizardry.wizardry.api.util.RandUtil;
 import com.teamwizardry.wizardry.common.module.modifiers.ModuleModifierIncreasePotency;
@@ -37,7 +39,7 @@ import javax.annotation.Nonnull;
  * Created by Demoniaque.
  */
 @RegisterModule
-public class ModuleEffectLeech extends ModuleEffect {
+public class ModuleEffectLeech implements IModuleEffect {
 
 	@Nonnull
 	@Override
@@ -46,12 +48,12 @@ public class ModuleEffectLeech extends ModuleEffect {
 	}
 
 	@Override
-	public ModuleModifier[] applicableModifiers() {
-		return new ModuleModifier[]{new ModuleModifierIncreasePotency()};
+	public IModuleModifier[] applicableModifiers() {
+		return new IModuleModifier[]{new ModuleModifierIncreasePotency()};
 	}
 
 	@Override
-	public boolean run(@Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public boolean run(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		World world = spell.world;
 		Entity targetEntity = spell.getVictim();
 		Entity caster = spell.getCaster();
@@ -103,7 +105,7 @@ public class ModuleEffectLeech extends ModuleEffect {
 
 	@Override
 	@SideOnly(Side.CLIENT)
-	public void renderSpell(@Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public void renderSpell(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		World world = spell.world;
 		Vec3d position = spell.getTarget();
 

--- a/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectLeech.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectLeech.java
@@ -12,8 +12,7 @@ import com.teamwizardry.wizardry.api.spell.SpellRing;
 import com.teamwizardry.wizardry.api.spell.attribute.AttributeRegistry;
 import com.teamwizardry.wizardry.api.spell.module.IModuleEffect;
 import com.teamwizardry.wizardry.api.spell.module.IModuleModifier;
-import com.teamwizardry.wizardry.api.spell.module.Module;
-import com.teamwizardry.wizardry.api.spell.module.ModuleEffect;
+import com.teamwizardry.wizardry.api.spell.module.ModuleInstanceEffect;
 import com.teamwizardry.wizardry.api.spell.module.RegisterModule;
 import com.teamwizardry.wizardry.api.util.RandUtil;
 import com.teamwizardry.wizardry.common.module.modifiers.ModuleModifierIncreasePotency;
@@ -53,7 +52,7 @@ public class ModuleEffectLeech implements IModuleEffect {
 	}
 
 	@Override
-	public boolean run(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public boolean run(ModuleInstanceEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		World world = spell.world;
 		Entity targetEntity = spell.getVictim();
 		Entity caster = spell.getCaster();
@@ -105,7 +104,7 @@ public class ModuleEffectLeech implements IModuleEffect {
 
 	@Override
 	@SideOnly(Side.CLIENT)
-	public void renderSpell(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public void renderSpell(ModuleInstanceEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		World world = spell.world;
 		Vec3d position = spell.getTarget();
 

--- a/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectLeech.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectLeech.java
@@ -43,7 +43,7 @@ public class ModuleEffectLeech implements IModuleEffect {
 
 	@Nonnull
 	@Override
-	public String getID() {
+	public String getClassID() {
 		return "effect_leech";
 	}
 

--- a/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectLight.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectLight.java
@@ -9,11 +9,14 @@ import com.teamwizardry.wizardry.Wizardry;
 import com.teamwizardry.wizardry.api.Constants;
 import com.teamwizardry.wizardry.api.spell.SpellData;
 import com.teamwizardry.wizardry.api.spell.SpellRing;
+import com.teamwizardry.wizardry.api.spell.module.IModuleEffect;
+import com.teamwizardry.wizardry.api.spell.module.Module;
 import com.teamwizardry.wizardry.api.spell.module.ModuleEffect;
 import com.teamwizardry.wizardry.api.spell.module.RegisterModule;
 import com.teamwizardry.wizardry.api.util.BlockUtils;
 import com.teamwizardry.wizardry.api.util.RandUtil;
 import com.teamwizardry.wizardry.api.util.interp.InterpScale;
+import com.teamwizardry.wizardry.common.tile.TileLight;
 import com.teamwizardry.wizardry.init.ModBlocks;
 import com.teamwizardry.wizardry.init.ModSounds;
 import net.minecraft.entity.Entity;
@@ -34,7 +37,7 @@ import javax.annotation.Nonnull;
  * Created by Demoniaque.
  */
 @RegisterModule
-public class ModuleEffectLight extends ModuleEffect {
+public class ModuleEffectLight implements IModuleEffect {
 
 	@Nonnull
 	@Override
@@ -43,7 +46,7 @@ public class ModuleEffectLight extends ModuleEffect {
 	}
 
 	@Override
-	public boolean run(@Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public boolean run(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		World world = spell.world;
 		BlockPos targetPos = spell.getTargetPos();
 		EnumFacing facing = spell.getFaceHit();
@@ -57,6 +60,11 @@ public class ModuleEffectLight extends ModuleEffect {
 		if (facing != null && world.isAirBlock(targetPos.offset(facing))) finalPos = targetPos.offset(facing);
 
 		BlockUtils.placeBlock(world, finalPos, ModBlocks.LIGHT.getDefaultState(), caster instanceof EntityPlayerMP ? (EntityPlayerMP) caster : null);
+		TileLight te = BlockUtils.getTileEntity(world, finalPos, TileLight.class);
+		if( te != null ) {
+			// Should be always the case.
+			te.setModule(instance);
+		}
 
 		world.playSound(null, targetPos, ModSounds.SPARKLE, SoundCategory.AMBIENT, 1f, 1f);
 
@@ -65,7 +73,7 @@ public class ModuleEffectLight extends ModuleEffect {
 
 	@Override
 	@SideOnly(Side.CLIENT)
-	public void renderSpell(@Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public void renderSpell(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		World world = spell.world;
 		BlockPos position = spell.getTargetPos();
 		EnumFacing facing = spell.getFaceHit();
@@ -92,9 +100,9 @@ public class ModuleEffectLight extends ModuleEffect {
 			build.setDeceleration(new Vec3d(0.4, 0.4, 0.4));
 
 			if (RandUtil.nextBoolean()) {
-				build.setColorFunction(new InterpColorHSV(getPrimaryColor(), getSecondaryColor()));
+				build.setColorFunction(new InterpColorHSV(instance.getPrimaryColor(), instance.getSecondaryColor()));
 			} else {
-				build.setColorFunction(new InterpColorHSV(getSecondaryColor(), getPrimaryColor()));
+				build.setColorFunction(new InterpColorHSV(instance.getSecondaryColor(), instance.getPrimaryColor()));
 			}
 		});
 	}

--- a/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectLight.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectLight.java
@@ -41,7 +41,7 @@ public class ModuleEffectLight implements IModuleEffect {
 
 	@Nonnull
 	@Override
-	public String getID() {
+	public String getClassID() {
 		return "effect_light";
 	}
 

--- a/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectLight.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectLight.java
@@ -10,8 +10,7 @@ import com.teamwizardry.wizardry.api.Constants;
 import com.teamwizardry.wizardry.api.spell.SpellData;
 import com.teamwizardry.wizardry.api.spell.SpellRing;
 import com.teamwizardry.wizardry.api.spell.module.IModuleEffect;
-import com.teamwizardry.wizardry.api.spell.module.Module;
-import com.teamwizardry.wizardry.api.spell.module.ModuleEffect;
+import com.teamwizardry.wizardry.api.spell.module.ModuleInstanceEffect;
 import com.teamwizardry.wizardry.api.spell.module.RegisterModule;
 import com.teamwizardry.wizardry.api.util.BlockUtils;
 import com.teamwizardry.wizardry.api.util.RandUtil;
@@ -46,7 +45,7 @@ public class ModuleEffectLight implements IModuleEffect {
 	}
 
 	@Override
-	public boolean run(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public boolean run(ModuleInstanceEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		World world = spell.world;
 		BlockPos targetPos = spell.getTargetPos();
 		EnumFacing facing = spell.getFaceHit();
@@ -73,7 +72,7 @@ public class ModuleEffectLight implements IModuleEffect {
 
 	@Override
 	@SideOnly(Side.CLIENT)
-	public void renderSpell(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public void renderSpell(ModuleInstanceEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		World world = spell.world;
 		BlockPos position = spell.getTargetPos();
 		EnumFacing facing = spell.getFaceHit();

--- a/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectLightning.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectLightning.java
@@ -7,8 +7,7 @@ import com.teamwizardry.wizardry.api.spell.SpellRing;
 import com.teamwizardry.wizardry.api.spell.attribute.AttributeRegistry;
 import com.teamwizardry.wizardry.api.spell.module.IModuleEffect;
 import com.teamwizardry.wizardry.api.spell.module.IModuleModifier;
-import com.teamwizardry.wizardry.api.spell.module.Module;
-import com.teamwizardry.wizardry.api.spell.module.ModuleEffect;
+import com.teamwizardry.wizardry.api.spell.module.ModuleInstanceEffect;
 import com.teamwizardry.wizardry.api.spell.module.OverrideConsumer;
 import com.teamwizardry.wizardry.api.spell.module.RegisterModule;
 import com.teamwizardry.wizardry.api.util.PosUtils;
@@ -48,7 +47,7 @@ import static com.teamwizardry.wizardry.api.spell.SpellData.DefaultKeys.*;
 public class ModuleEffectLightning implements IModuleEffect {
 
 	@Override
-	public void initEffect(ModuleEffect instance) {
+	public void initEffect(ModuleInstanceEffect instance) {
 		instance.registerRunOverride("shape_self", getSelfOverride());
 		instance.registerRunOverride("shape_touch", getTouchOverride());
 		instance.registerRunOverride("shape_projectile", getProjectileOverride());
@@ -229,7 +228,7 @@ public class ModuleEffectLightning implements IModuleEffect {
 	}
 	
 	@Override
-	public boolean run(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public boolean run(ModuleInstanceEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		// NO-OP, should always be overriding a shape
 		return true;
 	}
@@ -237,7 +236,7 @@ public class ModuleEffectLightning implements IModuleEffect {
 	
 	@Override
 	@SideOnly(Side.CLIENT)
-	public void renderSpell(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public void renderSpell(ModuleInstanceEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		// NO-OP, should always be overriding a shape
 	}
 	

--- a/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectLightning.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectLightning.java
@@ -5,8 +5,10 @@ import com.teamwizardry.wizardry.api.LightningGenerator;
 import com.teamwizardry.wizardry.api.spell.SpellData;
 import com.teamwizardry.wizardry.api.spell.SpellRing;
 import com.teamwizardry.wizardry.api.spell.attribute.AttributeRegistry;
+import com.teamwizardry.wizardry.api.spell.module.IModuleEffect;
+import com.teamwizardry.wizardry.api.spell.module.IModuleModifier;
+import com.teamwizardry.wizardry.api.spell.module.Module;
 import com.teamwizardry.wizardry.api.spell.module.ModuleEffect;
-import com.teamwizardry.wizardry.api.spell.module.ModuleModifier;
 import com.teamwizardry.wizardry.api.spell.module.OverrideConsumer;
 import com.teamwizardry.wizardry.api.spell.module.RegisterModule;
 import com.teamwizardry.wizardry.api.util.PosUtils;
@@ -43,20 +45,21 @@ import static com.teamwizardry.wizardry.api.spell.SpellData.DefaultKeys.*;
  * Created by Demoniaque.
  */
 @RegisterModule
-public class ModuleEffectLightning extends ModuleEffect {
+public class ModuleEffectLightning implements IModuleEffect {
 
-	public ModuleEffectLightning() {
-		registerRunOverride("shape_self", getSelfOverride());
-		registerRunOverride("shape_touch", getTouchOverride());
-		registerRunOverride("shape_projectile", getProjectileOverride());
-		registerRunOverride("shape_cone", getConeOverride());
-		registerRunOverride("shape_beam", getBeamOverride());
-		registerRunOverride("shape_zone", getZoneOverride());
+	@Override
+	public void initEffect(ModuleEffect instance) {
+		instance.registerRunOverride("shape_self", getSelfOverride());
+		instance.registerRunOverride("shape_touch", getTouchOverride());
+		instance.registerRunOverride("shape_projectile", getProjectileOverride());
+		instance.registerRunOverride("shape_cone", getConeOverride());
+		instance.registerRunOverride("shape_beam", getBeamOverride());
+		instance.registerRunOverride("shape_zone", getZoneOverride());
 
-		registerRenderOverride("shape_touch", (data, spellRing, childRing) -> {});
-		registerRenderOverride("shape_projectile", (data, spellRing, childRing) -> {});
-		registerRenderOverride("shape_cone", (data, spellRing, childRing) -> {});
-		registerRenderOverride("shape_beam", (data, spellRing, childRing) -> {});
+		instance.registerRenderOverride("shape_touch", (data, spellRing, childRing) -> {});
+		instance.registerRenderOverride("shape_projectile", (data, spellRing, childRing) -> {});
+		instance.registerRenderOverride("shape_cone", (data, spellRing, childRing) -> {});
+		instance.registerRenderOverride("shape_beam", (data, spellRing, childRing) -> {});
 	}
 
 	@Nonnull
@@ -66,8 +69,8 @@ public class ModuleEffectLightning extends ModuleEffect {
 	}
 
 	@Override
-	public ModuleModifier[] applicableModifiers() {
-		return new ModuleModifier[]{new ModuleModifierIncreaseRange(), new ModuleModifierIncreasePotency(), new ModuleModifierIncreaseDuration()};
+	public IModuleModifier[] applicableModifiers() {
+		return new IModuleModifier[]{new ModuleModifierIncreaseRange(), new ModuleModifierIncreasePotency(), new ModuleModifierIncreaseDuration()};
 	}
 
 	private OverrideConsumer<SpellData, SpellRing, SpellRing> getSelfOverride() {
@@ -226,7 +229,7 @@ public class ModuleEffectLightning extends ModuleEffect {
 	}
 	
 	@Override
-	public boolean run(@Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public boolean run(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		// NO-OP, should always be overriding a shape
 		return true;
 	}
@@ -234,7 +237,7 @@ public class ModuleEffectLightning extends ModuleEffect {
 	
 	@Override
 	@SideOnly(Side.CLIENT)
-	public void renderSpell(@Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public void renderSpell(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		// NO-OP, should always be overriding a shape
 	}
 	

--- a/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectLightning.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectLightning.java
@@ -64,7 +64,7 @@ public class ModuleEffectLightning implements IModuleEffect {
 
 	@Nonnull
 	@Override
-	public String getID() {
+	public String getClassID() {
 		return "effect_lightning";
 	}
 

--- a/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectLowGravity.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectLowGravity.java
@@ -9,8 +9,9 @@ import com.teamwizardry.wizardry.api.Constants;
 import com.teamwizardry.wizardry.api.spell.SpellData;
 import com.teamwizardry.wizardry.api.spell.SpellRing;
 import com.teamwizardry.wizardry.api.spell.attribute.AttributeRegistry;
+import com.teamwizardry.wizardry.api.spell.module.IModuleEffect;
+import com.teamwizardry.wizardry.api.spell.module.IModuleModifier;
 import com.teamwizardry.wizardry.api.spell.module.ModuleEffect;
-import com.teamwizardry.wizardry.api.spell.module.ModuleModifier;
 import com.teamwizardry.wizardry.api.spell.module.RegisterModule;
 import com.teamwizardry.wizardry.api.util.RandUtil;
 import com.teamwizardry.wizardry.api.util.interp.InterpScale;
@@ -36,7 +37,7 @@ import javax.annotation.Nonnull;
  * Created by Demoniaque.
  */
 @RegisterModule
-public class ModuleEffectLowGravity extends ModuleEffect {
+public class ModuleEffectLowGravity implements IModuleEffect {
 
 	@Nonnull
 	@Override
@@ -45,13 +46,13 @@ public class ModuleEffectLowGravity extends ModuleEffect {
 	}
 
 	@Override
-	public ModuleModifier[] applicableModifiers() {
-		return new ModuleModifier[]{new ModuleModifierIncreasePotency(), new ModuleModifierIncreaseDuration()};
+	public IModuleModifier[] applicableModifiers() {
+		return new IModuleModifier[]{new ModuleModifierIncreasePotency(), new ModuleModifierIncreaseDuration()};
 	}
 
 	@Override
 	@SuppressWarnings("unused")
-	public boolean run(@Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public boolean run(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		World world = spell.world;
 		Entity targetEntity = spell.getVictim();
 		BlockPos targetPos = spell.getTargetPos();
@@ -71,7 +72,7 @@ public class ModuleEffectLowGravity extends ModuleEffect {
 
 	@Override
 	@SideOnly(Side.CLIENT)
-	public void renderSpell(@Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public void renderSpell(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		World world = spell.world;
 		Vec3d position = spell.getTarget();
 

--- a/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectLowGravity.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectLowGravity.java
@@ -41,7 +41,7 @@ public class ModuleEffectLowGravity implements IModuleEffect {
 
 	@Nonnull
 	@Override
-	public String getID() {
+	public String getClassID() {
 		return "effect_low_gravity";
 	}
 

--- a/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectLowGravity.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectLowGravity.java
@@ -11,7 +11,7 @@ import com.teamwizardry.wizardry.api.spell.SpellRing;
 import com.teamwizardry.wizardry.api.spell.attribute.AttributeRegistry;
 import com.teamwizardry.wizardry.api.spell.module.IModuleEffect;
 import com.teamwizardry.wizardry.api.spell.module.IModuleModifier;
-import com.teamwizardry.wizardry.api.spell.module.ModuleEffect;
+import com.teamwizardry.wizardry.api.spell.module.ModuleInstanceEffect;
 import com.teamwizardry.wizardry.api.spell.module.RegisterModule;
 import com.teamwizardry.wizardry.api.util.RandUtil;
 import com.teamwizardry.wizardry.api.util.interp.InterpScale;
@@ -52,7 +52,7 @@ public class ModuleEffectLowGravity implements IModuleEffect {
 
 	@Override
 	@SuppressWarnings("unused")
-	public boolean run(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public boolean run(ModuleInstanceEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		World world = spell.world;
 		Entity targetEntity = spell.getVictim();
 		BlockPos targetPos = spell.getTargetPos();
@@ -72,7 +72,7 @@ public class ModuleEffectLowGravity implements IModuleEffect {
 
 	@Override
 	@SideOnly(Side.CLIENT)
-	public void renderSpell(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public void renderSpell(ModuleInstanceEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		World world = spell.world;
 		Vec3d position = spell.getTarget();
 

--- a/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectPhase.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectPhase.java
@@ -61,7 +61,7 @@ public class ModuleEffectPhase implements IModuleEffect, IDelayedModule {
 
 	@Nonnull
 	@Override
-	public String getID() {
+	public String getClassID() {
 		return "effect_phase";
 	}
 

--- a/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectPhase.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectPhase.java
@@ -12,7 +12,7 @@ import com.teamwizardry.wizardry.api.spell.SpellRing;
 import com.teamwizardry.wizardry.api.spell.attribute.AttributeRegistry;
 import com.teamwizardry.wizardry.api.spell.module.IModuleEffect;
 import com.teamwizardry.wizardry.api.spell.module.IModuleModifier;
-import com.teamwizardry.wizardry.api.spell.module.ModuleEffect;
+import com.teamwizardry.wizardry.api.spell.module.ModuleInstanceEffect;
 import com.teamwizardry.wizardry.api.spell.module.ModuleRegistry;
 import com.teamwizardry.wizardry.api.spell.module.RegisterModule;
 import com.teamwizardry.wizardry.api.util.BlockUtils;
@@ -83,7 +83,7 @@ public class ModuleEffectPhase implements IModuleEffect, IDelayedModule {
 	}
 
 	@Override
-	public boolean run(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public boolean run(ModuleInstanceEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		Entity caster = spell.getCaster();
 		Entity targetEntity = spell.getVictim();
 		BlockPos targetPos = spell.getTargetPos();
@@ -249,7 +249,7 @@ public class ModuleEffectPhase implements IModuleEffect, IDelayedModule {
 
 	@Override
 	@SideOnly(Side.CLIENT)
-	public void renderSpell(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public void renderSpell(ModuleInstanceEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		EnumFacing faceHit = spell.getFaceHit();
 
 		Set<BlockPos> blockSet = spell.getData(SpellData.DefaultKeys.BLOCK_SET, new HashSet<>());
@@ -347,7 +347,7 @@ public class ModuleEffectPhase implements IModuleEffect, IDelayedModule {
 
 	@NotNull
 	@Override
-	public SpellData renderVisualization(ModuleEffect instance, @Nonnull SpellData data, @Nonnull SpellRing ring, @Nonnull SpellData previousData) {
+	public SpellData renderVisualization(ModuleInstanceEffect instance, @Nonnull SpellData data, @Nonnull SpellRing ring, @Nonnull SpellData previousData) {
 		if (ring.getParentRing() != null
 				&& ring.getParentRing().getModule() != null
 				&& ring.getParentRing().getModule() == ModuleRegistry.INSTANCE.getModule("event_collide_entity"))

--- a/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectPhase.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectPhase.java
@@ -10,8 +10,9 @@ import com.teamwizardry.wizardry.api.spell.IDelayedModule;
 import com.teamwizardry.wizardry.api.spell.SpellData;
 import com.teamwizardry.wizardry.api.spell.SpellRing;
 import com.teamwizardry.wizardry.api.spell.attribute.AttributeRegistry;
+import com.teamwizardry.wizardry.api.spell.module.IModuleEffect;
+import com.teamwizardry.wizardry.api.spell.module.IModuleModifier;
 import com.teamwizardry.wizardry.api.spell.module.ModuleEffect;
-import com.teamwizardry.wizardry.api.spell.module.ModuleModifier;
 import com.teamwizardry.wizardry.api.spell.module.ModuleRegistry;
 import com.teamwizardry.wizardry.api.spell.module.RegisterModule;
 import com.teamwizardry.wizardry.api.util.BlockUtils;
@@ -56,7 +57,7 @@ import static com.teamwizardry.wizardry.api.util.PosUtils.getPerpendicularFacing
  * Created by Demoniaque.
  */
 @RegisterModule
-public class ModuleEffectPhase extends ModuleEffect implements IDelayedModule {
+public class ModuleEffectPhase implements IModuleEffect, IDelayedModule {
 
 	@Nonnull
 	@Override
@@ -65,8 +66,8 @@ public class ModuleEffectPhase extends ModuleEffect implements IDelayedModule {
 	}
 
 	@Override
-	public ModuleModifier[] applicableModifiers() {
-		return new ModuleModifier[]{new ModuleModifierIncreaseDuration(), new ModuleModifierIncreaseAOE(), new ModuleModifierIncreaseRange()};
+	public IModuleModifier[] applicableModifiers() {
+		return new IModuleModifier[]{new ModuleModifierIncreaseDuration(), new ModuleModifierIncreaseAOE(), new ModuleModifierIncreaseRange()};
 	}
 
 	@Override
@@ -82,7 +83,7 @@ public class ModuleEffectPhase extends ModuleEffect implements IDelayedModule {
 	}
 
 	@Override
-	public boolean run(@Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public boolean run(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		Entity caster = spell.getCaster();
 		Entity targetEntity = spell.getVictim();
 		BlockPos targetPos = spell.getTargetPos();
@@ -240,7 +241,7 @@ public class ModuleEffectPhase extends ModuleEffect implements IDelayedModule {
 			spell.addData(SpellData.DefaultKeys.BLOCK_SET, poses);
 			spell.addData(SpellData.DefaultKeys.BLOCKSTATE_CACHE, stateCache);
 
-			addDelayedSpell(this, spellRing, spell, (int) duration);
+			addDelayedSpell(instance, spellRing, spell, (int) duration);
 		}
 
 		return true;
@@ -248,7 +249,7 @@ public class ModuleEffectPhase extends ModuleEffect implements IDelayedModule {
 
 	@Override
 	@SideOnly(Side.CLIENT)
-	public void renderSpell(@Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public void renderSpell(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		EnumFacing faceHit = spell.getFaceHit();
 
 		Set<BlockPos> blockSet = spell.getData(SpellData.DefaultKeys.BLOCK_SET, new HashSet<>());
@@ -346,7 +347,7 @@ public class ModuleEffectPhase extends ModuleEffect implements IDelayedModule {
 
 	@NotNull
 	@Override
-	public SpellData renderVisualization(@Nonnull SpellData data, @Nonnull SpellRing ring, @Nonnull SpellData previousData) {
+	public SpellData renderVisualization(ModuleEffect instance, @Nonnull SpellData data, @Nonnull SpellRing ring, @Nonnull SpellData previousData) {
 		if (ring.getParentRing() != null
 				&& ring.getParentRing().getModule() != null
 				&& ring.getParentRing().getModule() == ModuleRegistry.INSTANCE.getModule("event_collide_entity"))
@@ -360,7 +361,7 @@ public class ModuleEffectPhase extends ModuleEffect implements IDelayedModule {
 
 		if (faceHit != null && targetPos != null) {
 
-			IBlockState targetState = getCachableBlockstate(data.world, targetPos, previousData);
+			IBlockState targetState = instance.getCachableBlockstate(data.world, targetPos, previousData);
 			if (BlockUtils.isAnyAir(targetState)) return previousData;
 
 			BlockPos.MutableBlockPos mutable = new BlockPos.MutableBlockPos(targetPos);
@@ -430,7 +431,7 @@ public class ModuleEffectPhase extends ModuleEffect implements IDelayedModule {
 				boolean fullAirPlane = true;
 				for (BlockPos pos : BlockPos.getAllInBox((int) bb.minX, (int) bb.minY, (int) bb.minZ, (int) bb.maxX, (int) bb.maxY, (int) bb.maxZ)) {
 
-					IBlockState originalState = getCachableBlockstate(data.world, pos, previousData);
+					IBlockState originalState = instance.getCachableBlockstate(data.world, pos, previousData);
 					Block block = originalState.getBlock();
 
 					if (edges.contains(pos)) continue;
@@ -453,7 +454,7 @@ public class ModuleEffectPhase extends ModuleEffect implements IDelayedModule {
 							mutable2.move(facing);
 
 							if (!tmp.containsKey(mutable2))
-								drawFaceOutline(mutable2, facing.getOpposite());
+								instance.drawFaceOutline(mutable2, facing.getOpposite());
 
 							mutable2.move(facing.getOpposite());
 						}

--- a/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectPlace.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectPlace.java
@@ -4,8 +4,9 @@ import com.teamwizardry.wizardry.api.spell.IBlockSelectable;
 import com.teamwizardry.wizardry.api.spell.SpellData;
 import com.teamwizardry.wizardry.api.spell.SpellRing;
 import com.teamwizardry.wizardry.api.spell.attribute.AttributeRegistry;
+import com.teamwizardry.wizardry.api.spell.module.IModuleEffect;
+import com.teamwizardry.wizardry.api.spell.module.IModuleModifier;
 import com.teamwizardry.wizardry.api.spell.module.ModuleEffect;
-import com.teamwizardry.wizardry.api.spell.module.ModuleModifier;
 import com.teamwizardry.wizardry.api.spell.module.ModuleRegistry;
 import com.teamwizardry.wizardry.api.spell.module.RegisterModule;
 import com.teamwizardry.wizardry.api.util.BlockUtils;
@@ -39,7 +40,7 @@ import static com.teamwizardry.wizardry.api.spell.SpellData.DefaultKeys.FACE_HIT
  * Created by Demoniaque.
  */
 @RegisterModule
-public class ModuleEffectPlace extends ModuleEffect implements IBlockSelectable {
+public class ModuleEffectPlace implements IModuleEffect, IBlockSelectable {
 
 	@Nonnull
 	@Override
@@ -48,12 +49,12 @@ public class ModuleEffectPlace extends ModuleEffect implements IBlockSelectable 
 	}
 
 	@Override
-	public ModuleModifier[] applicableModifiers() {
-		return new ModuleModifier[]{new ModuleModifierIncreaseAOE()};
+	public IModuleModifier[] applicableModifiers() {
+		return new IModuleModifier[]{new ModuleModifierIncreaseAOE()};
 	}
 
 	@Override
-	public boolean run(@Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public boolean run(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		World world = spell.world;
 		BlockPos targetPos = spell.getData(BLOCK_HIT);
 		Entity caster = spell.getCaster();
@@ -64,14 +65,14 @@ public class ModuleEffectPlace extends ModuleEffect implements IBlockSelectable 
 		double area = spellRing.getAttributeValue(AttributeRegistry.AREA, spell);
 
 		if (caster instanceof EntityPlayer) {
-			IBlockState selected = getSelectedBlockState((EntityPlayer) caster);
+			IBlockState selected = instance.getSelectedBlockState((EntityPlayer) caster);
 			if (selected == null) return true;
 
 			IBlockState targetState = world.getBlockState(targetPos);
-			List<ItemStack> stacks = getAllOfStackFromInventory((EntityPlayer) caster, selected);
+			List<ItemStack> stacks = instance.getAllOfStackFromInventory((EntityPlayer) caster, selected);
 			if (stacks.isEmpty()) return true;
 			
-			int stackCount = getCountOfStacks(stacks);
+			int stackCount = instance.getCountOfStacks(stacks);
 			Set<BlockPos> blocks = BlockUtils.blocksInSquare(targetPos, facing, Math.min(stackCount, (int) area), (int) ((Math.sqrt(area)+1)/2), pos -> {
 				if (BlockUtils.isAnyAir(targetState)) return true;
 
@@ -93,7 +94,7 @@ public class ModuleEffectPlace extends ModuleEffect implements IBlockSelectable 
 
 				IBlockState oldState = world.getBlockState(pos);
 
-				ItemStack availableStack = getAvailableStack(stacks);
+				ItemStack availableStack = instance.getAvailableStack(stacks);
 				if (availableStack == null) return true;
 
 				BlockUtils.placeBlock(world, pos, facing, availableStack);
@@ -121,18 +122,18 @@ public class ModuleEffectPlace extends ModuleEffect implements IBlockSelectable 
 
 	@Override
 	@SideOnly(Side.CLIENT)
-	public void renderSpell(@Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public void renderSpell(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		World world = spell.world;
 		Vec3d position = spell.getTarget();
 
 		if (position == null) return;
 
-		LibParticles.EXPLODE(world, position, getPrimaryColor(), getSecondaryColor(), 0.2, 0.3, 20, 40, 10, true);
+		LibParticles.EXPLODE(world, position, instance.getPrimaryColor(), instance.getSecondaryColor(), 0.2, 0.3, 20, 40, 10, true);
 	}
 
 	@NotNull
 	@Override
-	public SpellData renderVisualization(@Nonnull SpellData data, @Nonnull SpellRing ring, @Nonnull SpellData previousData) {
+	public SpellData renderVisualization(ModuleEffect instance, @Nonnull SpellData data, @Nonnull SpellRing ring, @Nonnull SpellData previousData) {
 		if (ring.getParentRing() != null
 				&& ring.getParentRing().getModule() != null
 				&& ring.getParentRing().getModule() == ModuleRegistry.INSTANCE.getModule("event_collide_entity"))
@@ -147,29 +148,29 @@ public class ModuleEffectPlace extends ModuleEffect implements IBlockSelectable 
 		double area = ring.getAttributeValue(AttributeRegistry.AREA, data);
 
 		if (caster instanceof EntityPlayer) {
-			IBlockState selected = getSelectedBlockState((EntityPlayer) caster);
+			IBlockState selected = instance.getSelectedBlockState((EntityPlayer) caster);
 			if (selected == null) return previousData;
 
 			IBlockState targetState = data.world.getBlockState(targetPos);
-			List<ItemStack> stacks = getAllOfStackFromInventory((EntityPlayer) caster, selected);
+			List<ItemStack> stacks = instance.getAllOfStackFromInventory((EntityPlayer) caster, selected);
 			if (stacks.isEmpty()) return previousData;
 
-			int stackCount = getCountOfStacks(stacks);
+			int stackCount = instance.getCountOfStacks(stacks);
 			Set<BlockPos> blocks = BlockUtils.blocksInSquare(targetPos, facing, Math.min(stackCount, (int) area), (int) ((Math.sqrt(area)+1)/2), pos -> {
 				if (BlockUtils.isAnyAir(targetState)) return true;
 
 				BlockPos.MutableBlockPos mutable = new BlockPos.MutableBlockPos(pos);
-				IBlockState adjacentState = getCachableBlockstate(data.world, mutable.offset(facing), previousData);
+				IBlockState adjacentState = instance.getCachableBlockstate(data.world, mutable.offset(facing), previousData);
 				if (adjacentState.getBlock() != Blocks.AIR) return true;
 
-				IBlockState state = getCachableBlockstate(data.world, pos, previousData);
+				IBlockState state = instance.getCachableBlockstate(data.world, pos, previousData);
 				return state.getBlock() != targetState.getBlock();
 			});
 
 			if (blocks.isEmpty()) {
 				if (targetState.getBlock() == Blocks.AIR)
-					drawCubeOutline(data.world, targetPos, targetState);
-				else drawFaceOutline(targetPos, facing);
+					instance.drawCubeOutline(data.world, targetPos, targetState);
+				else instance.drawFaceOutline(targetPos, facing);
 			} else
 				for (BlockPos areaPos : blocks) {
 					BlockPos pos = areaPos.offset(facing);
@@ -181,7 +182,7 @@ public class ModuleEffectPlace extends ModuleEffect implements IBlockSelectable 
 
 						if (blocks.contains(mutable)) {
 
-							drawFaceOutline(mutable, facing1.getOpposite());
+							instance.drawFaceOutline(mutable, facing1.getOpposite());
 						}
 						mutable.move(facing1.getOpposite());
 					}

--- a/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectPlace.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectPlace.java
@@ -6,7 +6,7 @@ import com.teamwizardry.wizardry.api.spell.SpellRing;
 import com.teamwizardry.wizardry.api.spell.attribute.AttributeRegistry;
 import com.teamwizardry.wizardry.api.spell.module.IModuleEffect;
 import com.teamwizardry.wizardry.api.spell.module.IModuleModifier;
-import com.teamwizardry.wizardry.api.spell.module.ModuleEffect;
+import com.teamwizardry.wizardry.api.spell.module.ModuleInstanceEffect;
 import com.teamwizardry.wizardry.api.spell.module.ModuleRegistry;
 import com.teamwizardry.wizardry.api.spell.module.RegisterModule;
 import com.teamwizardry.wizardry.api.util.BlockUtils;
@@ -54,7 +54,7 @@ public class ModuleEffectPlace implements IModuleEffect, IBlockSelectable {
 	}
 
 	@Override
-	public boolean run(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public boolean run(ModuleInstanceEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		World world = spell.world;
 		BlockPos targetPos = spell.getData(BLOCK_HIT);
 		Entity caster = spell.getCaster();
@@ -122,7 +122,7 @@ public class ModuleEffectPlace implements IModuleEffect, IBlockSelectable {
 
 	@Override
 	@SideOnly(Side.CLIENT)
-	public void renderSpell(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public void renderSpell(ModuleInstanceEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		World world = spell.world;
 		Vec3d position = spell.getTarget();
 
@@ -133,7 +133,7 @@ public class ModuleEffectPlace implements IModuleEffect, IBlockSelectable {
 
 	@NotNull
 	@Override
-	public SpellData renderVisualization(ModuleEffect instance, @Nonnull SpellData data, @Nonnull SpellRing ring, @Nonnull SpellData previousData) {
+	public SpellData renderVisualization(ModuleInstanceEffect instance, @Nonnull SpellData data, @Nonnull SpellRing ring, @Nonnull SpellData previousData) {
 		if (ring.getParentRing() != null
 				&& ring.getParentRing().getModule() != null
 				&& ring.getParentRing().getModule() == ModuleRegistry.INSTANCE.getModule("event_collide_entity"))

--- a/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectPlace.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectPlace.java
@@ -44,7 +44,7 @@ public class ModuleEffectPlace implements IModuleEffect, IBlockSelectable {
 
 	@Nonnull
 	@Override
-	public String getID() {
+	public String getClassID() {
 		return "effect_place";
 	}
 

--- a/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectSubstitution.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectSubstitution.java
@@ -15,7 +15,7 @@ import com.teamwizardry.wizardry.api.spell.SpellRing;
 import com.teamwizardry.wizardry.api.spell.attribute.AttributeRegistry;
 import com.teamwizardry.wizardry.api.spell.module.IModuleEffect;
 import com.teamwizardry.wizardry.api.spell.module.IModuleModifier;
-import com.teamwizardry.wizardry.api.spell.module.ModuleEffect;
+import com.teamwizardry.wizardry.api.spell.module.ModuleInstanceEffect;
 import com.teamwizardry.wizardry.api.spell.module.ModuleRegistry;
 import com.teamwizardry.wizardry.api.spell.module.RegisterModule;
 import com.teamwizardry.wizardry.api.util.BlockUtils;
@@ -68,7 +68,7 @@ public class ModuleEffectSubstitution implements IModuleEffect, IBlockSelectable
 	}
 
 	@Override
-	public boolean run(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public boolean run(ModuleInstanceEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		Entity targetEntity = spell.getVictim();
 		Entity caster = spell.getCaster();
 		BlockPos targetBlock = spell.getTargetPos();
@@ -161,7 +161,7 @@ public class ModuleEffectSubstitution implements IModuleEffect, IBlockSelectable
 
 	@Override
 	@SideOnly(Side.CLIENT)
-	public void renderSpell(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public void renderSpell(ModuleInstanceEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		World world = spell.world;
 		Entity caster = spell.getCaster();
 		BlockPos targetBlock = spell.getTargetPos();
@@ -216,7 +216,7 @@ public class ModuleEffectSubstitution implements IModuleEffect, IBlockSelectable
 
 	@NotNull
 	@Override
-	public SpellData renderVisualization(ModuleEffect instance, @Nonnull SpellData data, @Nonnull SpellRing ring, @Nonnull SpellData previousData) {
+	public SpellData renderVisualization(ModuleInstanceEffect instance, @Nonnull SpellData data, @Nonnull SpellRing ring, @Nonnull SpellData previousData) {
 		if (ring.getParentRing() != null
 				&& ring.getParentRing().getModule() != null
 				&& ring.getParentRing().getModule() == ModuleRegistry.INSTANCE.getModule("event_collide_entity"))

--- a/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectSubstitution.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectSubstitution.java
@@ -57,7 +57,7 @@ public class ModuleEffectSubstitution implements IModuleEffect, IBlockSelectable
 
 	@Nonnull
 	@Override
-	public String getID() {
+	public String getClassID() {
 		return "effect_substitution";
 	}
 

--- a/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectSubstitution.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectSubstitution.java
@@ -13,8 +13,9 @@ import com.teamwizardry.wizardry.api.spell.IBlockSelectable;
 import com.teamwizardry.wizardry.api.spell.SpellData;
 import com.teamwizardry.wizardry.api.spell.SpellRing;
 import com.teamwizardry.wizardry.api.spell.attribute.AttributeRegistry;
+import com.teamwizardry.wizardry.api.spell.module.IModuleEffect;
+import com.teamwizardry.wizardry.api.spell.module.IModuleModifier;
 import com.teamwizardry.wizardry.api.spell.module.ModuleEffect;
-import com.teamwizardry.wizardry.api.spell.module.ModuleModifier;
 import com.teamwizardry.wizardry.api.spell.module.ModuleRegistry;
 import com.teamwizardry.wizardry.api.spell.module.RegisterModule;
 import com.teamwizardry.wizardry.api.util.BlockUtils;
@@ -52,7 +53,7 @@ import java.util.Set;
  * Created by Demoniaque.
  */
 @RegisterModule
-public class ModuleEffectSubstitution extends ModuleEffect implements IBlockSelectable {
+public class ModuleEffectSubstitution implements IModuleEffect, IBlockSelectable {
 
 	@Nonnull
 	@Override
@@ -62,12 +63,12 @@ public class ModuleEffectSubstitution extends ModuleEffect implements IBlockSele
 
 
 	@Override
-	public ModuleModifier[] applicableModifiers() {
-		return new ModuleModifier[]{new ModuleModifierIncreaseAOE()};
+	public IModuleModifier[] applicableModifiers() {
+		return new IModuleModifier[]{new ModuleModifierIncreaseAOE()};
 	}
 
 	@Override
-	public boolean run(@Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public boolean run(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		Entity targetEntity = spell.getVictim();
 		Entity caster = spell.getCaster();
 		BlockPos targetBlock = spell.getTargetPos();
@@ -160,7 +161,7 @@ public class ModuleEffectSubstitution extends ModuleEffect implements IBlockSele
 
 	@Override
 	@SideOnly(Side.CLIENT)
-	public void renderSpell(@Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public void renderSpell(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		World world = spell.world;
 		Entity caster = spell.getCaster();
 		BlockPos targetBlock = spell.getTargetPos();
@@ -170,7 +171,7 @@ public class ModuleEffectSubstitution extends ModuleEffect implements IBlockSele
 
 			ParticleBuilder glitter = new ParticleBuilder(RandUtil.nextInt(20, 30));
 			glitter.setRender(new ResourceLocation(Wizardry.MODID, Constants.MISC.SPARKLE_BLURRED));
-			glitter.setColorFunction(new InterpColorHSV(getPrimaryColor(), getSecondaryColor()));
+			glitter.setColorFunction(new InterpColorHSV(instance.getPrimaryColor(), instance.getSecondaryColor()));
 			ParticleSpawner.spawn(glitter, world, new StaticInterp<>(new Vec3d(targetEntity.posX, targetEntity.posY, targetEntity.posZ)), 50, RandUtil.nextInt(20, 30), (aFloat, particleBuilder) -> {
 				glitter.setScale((float) RandUtil.nextDouble(0.3, 1));
 				glitter.setAlphaFunction(new InterpFloatInOut(0.3f, (float) RandUtil.nextDouble(0.6, 1)));
@@ -183,7 +184,7 @@ public class ModuleEffectSubstitution extends ModuleEffect implements IBlockSele
 				));
 			});
 
-			glitter.setColorFunction(new InterpColorHSV(getSecondaryColor(), getPrimaryColor()));
+			glitter.setColorFunction(new InterpColorHSV(instance.getSecondaryColor(), instance.getPrimaryColor()));
 			ParticleSpawner.spawn(glitter, world, new StaticInterp<>(new Vec3d(caster.posX, caster.posY, caster.posZ)), 50, RandUtil.nextInt(20, 30), (aFloat, particleBuilder) -> {
 				glitter.setScale((float) RandUtil.nextDouble(0.3, 1));
 				glitter.setAlphaFunction(new InterpFloatInOut(0.3f, (float) RandUtil.nextDouble(0.6, 1)));
@@ -198,7 +199,7 @@ public class ModuleEffectSubstitution extends ModuleEffect implements IBlockSele
 		} else if (targetBlock != null) {
 			ParticleBuilder glitter = new ParticleBuilder(RandUtil.nextInt(20, 30));
 			glitter.setRender(new ResourceLocation(Wizardry.MODID, Constants.MISC.SPARKLE_BLURRED));
-			glitter.setColorFunction(new InterpColorHSV(getPrimaryColor(), getSecondaryColor()));
+			glitter.setColorFunction(new InterpColorHSV(instance.getPrimaryColor(), instance.getSecondaryColor()));
 			ParticleSpawner.spawn(glitter, world, new StaticInterp<>(new Vec3d(targetBlock).add(0.5, 0.5, 0.5)), 20, 0, (aFloat, particleBuilder) -> {
 				glitter.setScale((float) RandUtil.nextDouble(0.3, 1));
 				glitter.setAlphaFunction(new InterpFloatInOut(0.3f, (float) RandUtil.nextDouble(0.6, 1)));
@@ -215,7 +216,7 @@ public class ModuleEffectSubstitution extends ModuleEffect implements IBlockSele
 
 	@NotNull
 	@Override
-	public SpellData renderVisualization(@Nonnull SpellData data, @Nonnull SpellRing ring, @Nonnull SpellData previousData) {
+	public SpellData renderVisualization(ModuleEffect instance, @Nonnull SpellData data, @Nonnull SpellRing ring, @Nonnull SpellData previousData) {
 		if (ring.getParentRing() != null
 				&& ring.getParentRing().getModule() != null
 				&& ring.getParentRing().getModule() == ModuleRegistry.INSTANCE.getModule("event_collide_entity"))
@@ -238,7 +239,7 @@ public class ModuleEffectSubstitution extends ModuleEffect implements IBlockSele
 				if (compound == null) return previousData;
 
 				IBlockState state = NBTUtil.readBlockState(compound);
-				IBlockState targetState = getCachableBlockstate(data.world, targetBlock, previousData);
+				IBlockState targetState = instance.getCachableBlockstate(data.world, targetBlock, previousData);
 				if (targetState.getBlock() == state.getBlock()) return previousData;
 
 				double area = ring.getAttributeValue(AttributeRegistry.AREA, data);
@@ -292,7 +293,7 @@ public class ModuleEffectSubstitution extends ModuleEffect implements IBlockSele
 
 						if (adjState.getBlock() != targetState.getBlock() || !blocks.contains(mutable)) {
 
-							drawFaceOutline(mutable, face.getOpposite());
+							instance.drawFaceOutline(mutable, face.getOpposite());
 						}
 						mutable.move(face.getOpposite());
 					}

--- a/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectTelekinesis.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectTelekinesis.java
@@ -40,7 +40,7 @@ public class ModuleEffectTelekinesis implements IModuleEffect, IContinuousModule
 
 	@Nonnull
 	@Override
-	public String getID() {
+	public String getClassID() {
 		return "effect_telekinesis";
 	}
 

--- a/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectTelekinesis.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectTelekinesis.java
@@ -13,7 +13,7 @@ import com.teamwizardry.wizardry.api.spell.SpellRing;
 import com.teamwizardry.wizardry.api.spell.attribute.AttributeRegistry;
 import com.teamwizardry.wizardry.api.spell.module.IModuleEffect;
 import com.teamwizardry.wizardry.api.spell.module.IModuleModifier;
-import com.teamwizardry.wizardry.api.spell.module.ModuleEffect;
+import com.teamwizardry.wizardry.api.spell.module.ModuleInstanceEffect;
 import com.teamwizardry.wizardry.api.spell.module.RegisterModule;
 import com.teamwizardry.wizardry.api.util.RandUtil;
 import com.teamwizardry.wizardry.api.util.interp.InterpScale;
@@ -50,7 +50,7 @@ public class ModuleEffectTelekinesis implements IModuleEffect, IContinuousModule
 	}
 
 	@Override
-	public boolean run(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public boolean run(ModuleInstanceEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		World world = spell.world;
 		Vec3d targetPos = spell.getTarget();
 		Entity caster = spell.getCaster();
@@ -86,7 +86,7 @@ public class ModuleEffectTelekinesis implements IModuleEffect, IContinuousModule
 
 	@Override
 	@SideOnly(Side.CLIENT)
-	public void renderSpell(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public void renderSpell(ModuleInstanceEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		World world = spell.world;
 		Vec3d position = spell.getTarget();
 

--- a/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectTelekinesis.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectTelekinesis.java
@@ -11,8 +11,9 @@ import com.teamwizardry.wizardry.api.spell.IContinuousModule;
 import com.teamwizardry.wizardry.api.spell.SpellData;
 import com.teamwizardry.wizardry.api.spell.SpellRing;
 import com.teamwizardry.wizardry.api.spell.attribute.AttributeRegistry;
+import com.teamwizardry.wizardry.api.spell.module.IModuleEffect;
+import com.teamwizardry.wizardry.api.spell.module.IModuleModifier;
 import com.teamwizardry.wizardry.api.spell.module.ModuleEffect;
-import com.teamwizardry.wizardry.api.spell.module.ModuleModifier;
 import com.teamwizardry.wizardry.api.spell.module.RegisterModule;
 import com.teamwizardry.wizardry.api.util.RandUtil;
 import com.teamwizardry.wizardry.api.util.interp.InterpScale;
@@ -35,7 +36,7 @@ import java.util.List;
  * Created by Demoniaque.
  */
 @RegisterModule
-public class ModuleEffectTelekinesis extends ModuleEffect implements IContinuousModule {
+public class ModuleEffectTelekinesis implements IModuleEffect, IContinuousModule {
 
 	@Nonnull
 	@Override
@@ -44,12 +45,12 @@ public class ModuleEffectTelekinesis extends ModuleEffect implements IContinuous
 	}
 
 	@Override
-	public ModuleModifier[] applicableModifiers() {
-		return new ModuleModifier[]{new ModuleModifierIncreaseAOE()};
+	public IModuleModifier[] applicableModifiers() {
+		return new IModuleModifier[]{new ModuleModifierIncreaseAOE()};
 	}
 
 	@Override
-	public boolean run(@Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public boolean run(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		World world = spell.world;
 		Vec3d targetPos = spell.getTarget();
 		Entity caster = spell.getCaster();
@@ -85,14 +86,14 @@ public class ModuleEffectTelekinesis extends ModuleEffect implements IContinuous
 
 	@Override
 	@SideOnly(Side.CLIENT)
-	public void renderSpell(@Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public void renderSpell(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		World world = spell.world;
 		Vec3d position = spell.getTarget();
 
 		if (position == null) return;
 
 		ParticleBuilder glitter = new ParticleBuilder(50);
-		glitter.setColorFunction(new InterpColorHSV(getPrimaryColor(), getSecondaryColor()));
+		glitter.setColorFunction(new InterpColorHSV(instance.getPrimaryColor(), instance.getSecondaryColor()));
 		glitter.setScale(1);
 		glitter.setRender(new ResourceLocation(Wizardry.MODID, Constants.MISC.SPARKLE_BLURRED));
 

--- a/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectThrive.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectThrive.java
@@ -3,8 +3,9 @@ package com.teamwizardry.wizardry.common.module.effects;
 import com.teamwizardry.wizardry.api.spell.SpellData;
 import com.teamwizardry.wizardry.api.spell.SpellRing;
 import com.teamwizardry.wizardry.api.spell.attribute.AttributeRegistry;
+import com.teamwizardry.wizardry.api.spell.module.IModuleEffect;
+import com.teamwizardry.wizardry.api.spell.module.IModuleModifier;
 import com.teamwizardry.wizardry.api.spell.module.ModuleEffect;
-import com.teamwizardry.wizardry.api.spell.module.ModuleModifier;
 import com.teamwizardry.wizardry.api.spell.module.RegisterModule;
 import com.teamwizardry.wizardry.api.util.BlockUtils;
 import com.teamwizardry.wizardry.api.util.RandUtil;
@@ -35,7 +36,7 @@ import javax.annotation.Nonnull;
  * Created by Demoniaque.
  */
 @RegisterModule
-public class ModuleEffectThrive extends ModuleEffect {
+public class ModuleEffectThrive implements IModuleEffect {
 
 	@Nonnull
 	@Override
@@ -44,12 +45,12 @@ public class ModuleEffectThrive extends ModuleEffect {
 	}
 
 	@Override
-	public ModuleModifier[] applicableModifiers() {
-		return new ModuleModifier[]{new ModuleModifierIncreasePotency()};
+	public IModuleModifier[] applicableModifiers() {
+		return new IModuleModifier[]{new ModuleModifierIncreasePotency()};
 	}
 
 	@Override
-	public boolean run(@Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public boolean run(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		World world = spell.world;
 		BlockPos targetPos = spell.getTargetPos();
 		Entity targetEntity = spell.getVictim();
@@ -90,11 +91,11 @@ public class ModuleEffectThrive extends ModuleEffect {
 
 	@Override
 	@SideOnly(Side.CLIENT)
-	public void renderSpell(@Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public void renderSpell(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		World world = spell.world;
 		Vec3d position = spell.getTarget();
 
 		if (position == null) return;
-		LibParticles.EFFECT_REGENERATE(world, position, getPrimaryColor());
+		LibParticles.EFFECT_REGENERATE(world, position, instance.getPrimaryColor());
 	}
 }

--- a/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectThrive.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectThrive.java
@@ -40,7 +40,7 @@ public class ModuleEffectThrive implements IModuleEffect {
 
 	@Nonnull
 	@Override
-	public String getID() {
+	public String getClassID() {
 		return "effect_thrive";
 	}
 

--- a/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectThrive.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectThrive.java
@@ -5,7 +5,7 @@ import com.teamwizardry.wizardry.api.spell.SpellRing;
 import com.teamwizardry.wizardry.api.spell.attribute.AttributeRegistry;
 import com.teamwizardry.wizardry.api.spell.module.IModuleEffect;
 import com.teamwizardry.wizardry.api.spell.module.IModuleModifier;
-import com.teamwizardry.wizardry.api.spell.module.ModuleEffect;
+import com.teamwizardry.wizardry.api.spell.module.ModuleInstanceEffect;
 import com.teamwizardry.wizardry.api.spell.module.RegisterModule;
 import com.teamwizardry.wizardry.api.util.BlockUtils;
 import com.teamwizardry.wizardry.api.util.RandUtil;
@@ -50,7 +50,7 @@ public class ModuleEffectThrive implements IModuleEffect {
 	}
 
 	@Override
-	public boolean run(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public boolean run(ModuleInstanceEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		World world = spell.world;
 		BlockPos targetPos = spell.getTargetPos();
 		Entity targetEntity = spell.getVictim();
@@ -91,7 +91,7 @@ public class ModuleEffectThrive implements IModuleEffect {
 
 	@Override
 	@SideOnly(Side.CLIENT)
-	public void renderSpell(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public void renderSpell(ModuleInstanceEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		World world = spell.world;
 		Vec3d position = spell.getTarget();
 

--- a/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectTimeLock.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectTimeLock.java
@@ -30,7 +30,7 @@ public class ModuleEffectTimeLock implements IModuleEffect, IDelayedModule {
 
 	@Nonnull
 	@Override
-	public String getID() {
+	public String getClassID() {
 		return "effect_time_lock";
 	}
 

--- a/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectTimeLock.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectTimeLock.java
@@ -4,8 +4,10 @@ import com.teamwizardry.wizardry.api.spell.IDelayedModule;
 import com.teamwizardry.wizardry.api.spell.SpellData;
 import com.teamwizardry.wizardry.api.spell.SpellRing;
 import com.teamwizardry.wizardry.api.spell.attribute.AttributeRegistry;
+import com.teamwizardry.wizardry.api.spell.module.IModuleEffect;
 import com.teamwizardry.wizardry.api.spell.module.ModuleEffect;
 import com.teamwizardry.wizardry.api.spell.module.ModuleModifier;
+import com.teamwizardry.wizardry.api.spell.module.IModuleModifier;
 import com.teamwizardry.wizardry.api.util.RandUtil;
 import com.teamwizardry.wizardry.client.fx.LibParticles;
 import com.teamwizardry.wizardry.common.module.modifiers.ModuleModifierIncreaseDuration;
@@ -24,7 +26,7 @@ import java.awt.*;
  * Created by Demoniaque.
  */
 //TODO: @RegisterModule
-public class ModuleEffectTimeLock extends ModuleEffect implements IDelayedModule {
+public class ModuleEffectTimeLock implements IModuleEffect, IDelayedModule {
 
 	@Nonnull
 	@Override
@@ -33,12 +35,12 @@ public class ModuleEffectTimeLock extends ModuleEffect implements IDelayedModule
 	}
 
 	@Override
-	public ModuleModifier[] applicableModifiers() {
-		return new ModuleModifier[]{new ModuleModifierIncreaseDuration()};
+	public IModuleModifier[] applicableModifiers() {
+		return new IModuleModifier[]{new ModuleModifierIncreaseDuration()};
 	}
 
 	@Override
-	public boolean run(@Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public boolean run(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		World world = spell.world;
 		Entity targetEntity = spell.getVictim();
 
@@ -60,14 +62,14 @@ public class ModuleEffectTimeLock extends ModuleEffect implements IDelayedModule
 
 	@Override
 	@SideOnly(Side.CLIENT)
-	public void renderSpell(@Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public void renderSpell(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		World world = spell.world;
 		Vec3d position = spell.getTarget();
 
 		if (position == null) return;
 
-		Color color = getPrimaryColor();
-		if (RandUtil.nextBoolean()) color = getSecondaryColor();
+		Color color = instance.getPrimaryColor();
+		if (RandUtil.nextBoolean()) color = instance.getSecondaryColor();
 
 		LibParticles.EFFECT_BURN(world, position, color);
 	}

--- a/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectTimeLock.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectTimeLock.java
@@ -5,8 +5,7 @@ import com.teamwizardry.wizardry.api.spell.SpellData;
 import com.teamwizardry.wizardry.api.spell.SpellRing;
 import com.teamwizardry.wizardry.api.spell.attribute.AttributeRegistry;
 import com.teamwizardry.wizardry.api.spell.module.IModuleEffect;
-import com.teamwizardry.wizardry.api.spell.module.ModuleEffect;
-import com.teamwizardry.wizardry.api.spell.module.ModuleModifier;
+import com.teamwizardry.wizardry.api.spell.module.ModuleInstanceEffect;
 import com.teamwizardry.wizardry.api.spell.module.IModuleModifier;
 import com.teamwizardry.wizardry.api.util.RandUtil;
 import com.teamwizardry.wizardry.client.fx.LibParticles;
@@ -40,7 +39,7 @@ public class ModuleEffectTimeLock implements IModuleEffect, IDelayedModule {
 	}
 
 	@Override
-	public boolean run(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public boolean run(ModuleInstanceEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		World world = spell.world;
 		Entity targetEntity = spell.getVictim();
 
@@ -62,7 +61,7 @@ public class ModuleEffectTimeLock implements IModuleEffect, IDelayedModule {
 
 	@Override
 	@SideOnly(Side.CLIENT)
-	public void renderSpell(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public void renderSpell(ModuleInstanceEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		World world = spell.world;
 		Vec3d position = spell.getTarget();
 

--- a/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectTimeSlow.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectTimeSlow.java
@@ -12,7 +12,7 @@ import com.teamwizardry.wizardry.api.spell.SpellRing;
 import com.teamwizardry.wizardry.api.spell.attribute.AttributeRegistry;
 import com.teamwizardry.wizardry.api.spell.module.IModuleEffect;
 import com.teamwizardry.wizardry.api.spell.module.IModuleModifier;
-import com.teamwizardry.wizardry.api.spell.module.ModuleEffect;
+import com.teamwizardry.wizardry.api.spell.module.ModuleInstanceEffect;
 import com.teamwizardry.wizardry.api.spell.module.RegisterModule;
 import com.teamwizardry.wizardry.api.util.RandUtil;
 import com.teamwizardry.wizardry.api.util.interp.InterpScale;
@@ -78,7 +78,7 @@ public class ModuleEffectTimeSlow implements IModuleEffect {
 
 	@Override
 	@SuppressWarnings("unused")
-	public boolean run(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public boolean run(ModuleInstanceEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		World world = spell.world;
 		BlockPos targetPos = spell.getTargetPos();
 		Entity targetEntity = spell.getVictim();
@@ -96,7 +96,7 @@ public class ModuleEffectTimeSlow implements IModuleEffect {
 
 	@Override
 	@SideOnly(Side.CLIENT)
-	public void renderSpell(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public void renderSpell(ModuleInstanceEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		World world = spell.world;
 		Vec3d position = spell.getTarget();
 

--- a/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectTimeSlow.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectTimeSlow.java
@@ -67,7 +67,7 @@ public class ModuleEffectTimeSlow implements IModuleEffect {
 
 	@Nonnull
 	@Override
-	public String getID() {
+	public String getClassID() {
 		return "effect_time_slow";
 	}
 

--- a/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectTimeSlow.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectTimeSlow.java
@@ -10,8 +10,9 @@ import com.teamwizardry.wizardry.api.Constants;
 import com.teamwizardry.wizardry.api.spell.SpellData;
 import com.teamwizardry.wizardry.api.spell.SpellRing;
 import com.teamwizardry.wizardry.api.spell.attribute.AttributeRegistry;
+import com.teamwizardry.wizardry.api.spell.module.IModuleEffect;
+import com.teamwizardry.wizardry.api.spell.module.IModuleModifier;
 import com.teamwizardry.wizardry.api.spell.module.ModuleEffect;
-import com.teamwizardry.wizardry.api.spell.module.ModuleModifier;
 import com.teamwizardry.wizardry.api.spell.module.RegisterModule;
 import com.teamwizardry.wizardry.api.util.RandUtil;
 import com.teamwizardry.wizardry.api.util.interp.InterpScale;
@@ -37,7 +38,7 @@ import javax.annotation.Nonnull;
  * Created by Demoniaque.
  */
 @RegisterModule
-public class ModuleEffectTimeSlow extends ModuleEffect {
+public class ModuleEffectTimeSlow implements IModuleEffect {
 
 	@SubscribeEvent
 	public static void skipTick(LivingEvent.LivingUpdateEvent event) {
@@ -71,13 +72,13 @@ public class ModuleEffectTimeSlow extends ModuleEffect {
 	}
 
 	@Override
-	public ModuleModifier[] applicableModifiers() {
-		return new ModuleModifier[]{new ModuleModifierIncreasePotency(), new ModuleModifierIncreaseDuration()};
+	public IModuleModifier[] applicableModifiers() {
+		return new IModuleModifier[]{new ModuleModifierIncreasePotency(), new ModuleModifierIncreaseDuration()};
 	}
 
 	@Override
 	@SuppressWarnings("unused")
-	public boolean run(@Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public boolean run(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		World world = spell.world;
 		BlockPos targetPos = spell.getTargetPos();
 		Entity targetEntity = spell.getVictim();
@@ -95,14 +96,14 @@ public class ModuleEffectTimeSlow extends ModuleEffect {
 
 	@Override
 	@SideOnly(Side.CLIENT)
-	public void renderSpell(@Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public void renderSpell(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		World world = spell.world;
 		Vec3d position = spell.getTarget();
 
 		if (position == null) return;
 
 		ParticleBuilder glitter = new ParticleBuilder(30);
-		glitter.setColorFunction(new InterpColorHSV(getPrimaryColor(), getSecondaryColor()));
+		glitter.setColorFunction(new InterpColorHSV(instance.getPrimaryColor(), instance.getSecondaryColor()));
 		glitter.setRender(new ResourceLocation(Wizardry.MODID, Constants.MISC.SPARKLE_BLURRED));
 		glitter.setScaleFunction(new InterpScale(1, 0));
 		glitter.setCollision(true);

--- a/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectVanish.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectVanish.java
@@ -28,7 +28,7 @@ public class ModuleEffectVanish implements IModuleEffect {
 
 	@Nonnull
 	@Override
-	public String getID() {
+	public String getClassID() {
 		return "effect_vanish";
 	}
 

--- a/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectVanish.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectVanish.java
@@ -5,7 +5,7 @@ import com.teamwizardry.wizardry.api.spell.SpellRing;
 import com.teamwizardry.wizardry.api.spell.attribute.AttributeRegistry;
 import com.teamwizardry.wizardry.api.spell.module.IModuleEffect;
 import com.teamwizardry.wizardry.api.spell.module.IModuleModifier;
-import com.teamwizardry.wizardry.api.spell.module.ModuleEffect;
+import com.teamwizardry.wizardry.api.spell.module.ModuleInstanceEffect;
 import com.teamwizardry.wizardry.api.spell.module.RegisterModule;
 import com.teamwizardry.wizardry.client.fx.LibParticles;
 import com.teamwizardry.wizardry.common.module.modifiers.ModuleModifierIncreaseDuration;
@@ -38,7 +38,7 @@ public class ModuleEffectVanish implements IModuleEffect {
 	}
 
 	@Override
-	public boolean run(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public boolean run(ModuleInstanceEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		Entity targetEntity = spell.getVictim();
 
 		double duration = spellRing.getAttributeValue(AttributeRegistry.DURATION, spell) * 20;
@@ -52,7 +52,7 @@ public class ModuleEffectVanish implements IModuleEffect {
 
 	@Override
 	@SideOnly(Side.CLIENT)
-	public void renderSpell(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public void renderSpell(ModuleInstanceEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		World world = spell.world;
 		Vec3d position = spell.getTarget();
 

--- a/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectVanish.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectVanish.java
@@ -3,8 +3,9 @@ package com.teamwizardry.wizardry.common.module.effects;
 import com.teamwizardry.wizardry.api.spell.SpellData;
 import com.teamwizardry.wizardry.api.spell.SpellRing;
 import com.teamwizardry.wizardry.api.spell.attribute.AttributeRegistry;
+import com.teamwizardry.wizardry.api.spell.module.IModuleEffect;
+import com.teamwizardry.wizardry.api.spell.module.IModuleModifier;
 import com.teamwizardry.wizardry.api.spell.module.ModuleEffect;
-import com.teamwizardry.wizardry.api.spell.module.ModuleModifier;
 import com.teamwizardry.wizardry.api.spell.module.RegisterModule;
 import com.teamwizardry.wizardry.client.fx.LibParticles;
 import com.teamwizardry.wizardry.common.module.modifiers.ModuleModifierIncreaseDuration;
@@ -23,7 +24,7 @@ import javax.annotation.Nonnull;
  * Created by Demoniaque.
  */
 @RegisterModule
-public class ModuleEffectVanish extends ModuleEffect {
+public class ModuleEffectVanish implements IModuleEffect {
 
 	@Nonnull
 	@Override
@@ -32,12 +33,12 @@ public class ModuleEffectVanish extends ModuleEffect {
 	}
 
 	@Override
-	public ModuleModifier[] applicableModifiers() {
-		return new ModuleModifier[]{new ModuleModifierIncreaseDuration()};
+	public IModuleModifier[] applicableModifiers() {
+		return new IModuleModifier[]{new ModuleModifierIncreaseDuration()};
 	}
 
 	@Override
-	public boolean run(@Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public boolean run(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		Entity targetEntity = spell.getVictim();
 
 		double duration = spellRing.getAttributeValue(AttributeRegistry.DURATION, spell) * 20;
@@ -51,13 +52,13 @@ public class ModuleEffectVanish extends ModuleEffect {
 
 	@Override
 	@SideOnly(Side.CLIENT)
-	public void renderSpell(@Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public void renderSpell(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		World world = spell.world;
 		Vec3d position = spell.getTarget();
 
 		if (position == null) return;
 
-		LibParticles.EFFECT_REGENERATE(world, position, getPrimaryColor());
+		LibParticles.EFFECT_REGENERATE(world, position, instance.getPrimaryColor());
 	}
 
 }

--- a/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectZoom.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectZoom.java
@@ -67,7 +67,7 @@ public class ModuleEffectZoom implements IModuleEffect {
 
 	@Nonnull
 	@Override
-	public String getID() {
+	public String getClassID() {
 		return "effect_zoom";
 	}
 

--- a/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectZoom.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectZoom.java
@@ -14,7 +14,7 @@ import com.teamwizardry.wizardry.api.spell.SpellRing;
 import com.teamwizardry.wizardry.api.spell.attribute.AttributeRegistry;
 import com.teamwizardry.wizardry.api.spell.module.IModuleEffect;
 import com.teamwizardry.wizardry.api.spell.module.IModuleModifier;
-import com.teamwizardry.wizardry.api.spell.module.ModuleEffect;
+import com.teamwizardry.wizardry.api.spell.module.ModuleInstanceEffect;
 import com.teamwizardry.wizardry.api.spell.module.RegisterModule;
 import com.teamwizardry.wizardry.api.util.RandUtil;
 import com.teamwizardry.wizardry.api.util.RayTrace;
@@ -77,7 +77,7 @@ public class ModuleEffectZoom implements IModuleEffect {
 	}
 
 	@Override
-	public boolean run(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public boolean run(ModuleInstanceEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		World world = spell.world;
 		Entity entityHit = spell.getVictim();
 		Vec3d look = spell.getData(LOOK);
@@ -116,7 +116,7 @@ public class ModuleEffectZoom implements IModuleEffect {
 
 	@Override
 	@SideOnly(Side.CLIENT)
-	public void renderSpell(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public void renderSpell(ModuleInstanceEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		World world = spell.world;
 
 		Entity entity = spell.getVictim();

--- a/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectZoom.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/effects/ModuleEffectZoom.java
@@ -12,8 +12,9 @@ import com.teamwizardry.wizardry.api.spell.ProcessData;
 import com.teamwizardry.wizardry.api.spell.SpellData;
 import com.teamwizardry.wizardry.api.spell.SpellRing;
 import com.teamwizardry.wizardry.api.spell.attribute.AttributeRegistry;
+import com.teamwizardry.wizardry.api.spell.module.IModuleEffect;
+import com.teamwizardry.wizardry.api.spell.module.IModuleModifier;
 import com.teamwizardry.wizardry.api.spell.module.ModuleEffect;
-import com.teamwizardry.wizardry.api.spell.module.ModuleModifier;
 import com.teamwizardry.wizardry.api.spell.module.RegisterModule;
 import com.teamwizardry.wizardry.api.util.RandUtil;
 import com.teamwizardry.wizardry.api.util.RayTrace;
@@ -42,7 +43,7 @@ import static com.teamwizardry.wizardry.api.spell.SpellData.constructPair;
  */
 // TODO: Tracer's blink sound effect
 @RegisterModule
-public class ModuleEffectZoom extends ModuleEffect {
+public class ModuleEffectZoom implements IModuleEffect {
 
 	private static final Pair<String, Class<Vec3d>> ORIGINAL_LOC = constructPair("original_loc", Vec3d.class, new ProcessData.Process<NBTTagCompound, Vec3d>() {
 		@Nonnull
@@ -71,12 +72,12 @@ public class ModuleEffectZoom extends ModuleEffect {
 	}
 
 	@Override
-	public ModuleModifier[] applicableModifiers() {
-		return new ModuleModifier[]{new ModuleModifierIncreaseRange()};
+	public IModuleModifier[] applicableModifiers() {
+		return new IModuleModifier[]{new ModuleModifierIncreaseRange()};
 	}
 
 	@Override
-	public boolean run(@Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public boolean run(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		World world = spell.world;
 		Entity entityHit = spell.getVictim();
 		Vec3d look = spell.getData(LOOK);
@@ -115,7 +116,7 @@ public class ModuleEffectZoom extends ModuleEffect {
 
 	@Override
 	@SideOnly(Side.CLIENT)
-	public void renderSpell(@Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public void renderSpell(ModuleEffect instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		World world = spell.world;
 
 		Entity entity = spell.getVictim();
@@ -151,7 +152,7 @@ public class ModuleEffectZoom extends ModuleEffect {
 				glitter.setAlpha(RandUtil.nextFloat(0.5f, 0.8f));
 				glitter.setScale(RandUtil.nextFloat(0.3f, 0.6f));
 				glitter.setLifetime(RandUtil.nextInt(30, 50));
-				glitter.setColorFunction(new InterpColorHSV(getPrimaryColor(), getSecondaryColor()));
+				glitter.setColorFunction(new InterpColorHSV(instance.getPrimaryColor(), instance.getSecondaryColor()));
 				glitter.setAlphaFunction(new InterpFloatInOut(0f, 1f));
 			});
 		});

--- a/src/main/java/com/teamwizardry/wizardry/common/module/events/ModuleEventCollideBlock.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/events/ModuleEventCollideBlock.java
@@ -20,7 +20,7 @@ public class ModuleEventCollideBlock implements IModuleEvent {
 
 	@Nonnull
 	@Override
-	public String getID() {
+	public String getClassID() {
 		return "event_collide_block";
 	}
 

--- a/src/main/java/com/teamwizardry/wizardry/common/module/events/ModuleEventCollideBlock.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/events/ModuleEventCollideBlock.java
@@ -1,22 +1,22 @@
 package com.teamwizardry.wizardry.common.module.events;
 
-import com.teamwizardry.wizardry.api.spell.SpellData;
-import com.teamwizardry.wizardry.api.spell.SpellRing;
-import com.teamwizardry.wizardry.api.spell.module.ModuleEvent;
-import com.teamwizardry.wizardry.api.spell.module.RegisterModule;
-import net.minecraft.util.math.BlockPos;
-import net.minecraftforge.fml.relauncher.Side;
-import net.minecraftforge.fml.relauncher.SideOnly;
+import static com.teamwizardry.wizardry.api.spell.SpellData.DefaultKeys.ENTITY_HIT;
 
 import javax.annotation.Nonnull;
 
-import static com.teamwizardry.wizardry.api.spell.SpellData.DefaultKeys.ENTITY_HIT;
+import com.teamwizardry.wizardry.api.spell.SpellData;
+import com.teamwizardry.wizardry.api.spell.SpellRing;
+import com.teamwizardry.wizardry.api.spell.module.IModuleEvent;
+import com.teamwizardry.wizardry.api.spell.module.ModuleEvent;
+import com.teamwizardry.wizardry.api.spell.module.RegisterModule;
+
+import net.minecraft.util.math.BlockPos;
 
 /**
  * Created by Demoniaque.
  */
 @RegisterModule
-public class ModuleEventCollideBlock extends ModuleEvent {
+public class ModuleEventCollideBlock implements IModuleEvent {
 
 	@Nonnull
 	@Override
@@ -25,15 +25,10 @@ public class ModuleEventCollideBlock extends ModuleEvent {
 	}
 
 	@Override
-	public boolean run(@Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public boolean run(ModuleEvent module, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		BlockPos pos = spell.getTargetPos();
 		spell.removeData(ENTITY_HIT);
 		return pos != null;
 	}
 
-	@Override
-	@SideOnly(Side.CLIENT)
-	public void renderSpell(@Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
-
-	}
 }

--- a/src/main/java/com/teamwizardry/wizardry/common/module/events/ModuleEventCollideEntity.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/events/ModuleEventCollideEntity.java
@@ -2,12 +2,11 @@ package com.teamwizardry.wizardry.common.module.events;
 
 import com.teamwizardry.wizardry.api.spell.SpellData;
 import com.teamwizardry.wizardry.api.spell.SpellRing;
+import com.teamwizardry.wizardry.api.spell.module.IModuleEvent;
+import com.teamwizardry.wizardry.api.spell.module.Module;
 import com.teamwizardry.wizardry.api.spell.module.ModuleEvent;
 import com.teamwizardry.wizardry.api.spell.module.RegisterModule;
 import net.minecraft.entity.Entity;
-import net.minecraftforge.fml.relauncher.Side;
-import net.minecraftforge.fml.relauncher.SideOnly;
-
 import javax.annotation.Nonnull;
 
 import static com.teamwizardry.wizardry.api.spell.SpellData.DefaultKeys.BLOCK_HIT;
@@ -16,7 +15,7 @@ import static com.teamwizardry.wizardry.api.spell.SpellData.DefaultKeys.BLOCK_HI
  * Created by Demoniaque.
  */
 @RegisterModule
-public class ModuleEventCollideEntity extends ModuleEvent {
+public class ModuleEventCollideEntity implements IModuleEvent {
 
 	@Nonnull
 	@Override
@@ -25,15 +24,9 @@ public class ModuleEventCollideEntity extends ModuleEvent {
 	}
 
 	@Override
-	public boolean run(@Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public boolean run(ModuleEvent instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		Entity entity = spell.getVictim();
 		spell.removeData(BLOCK_HIT);
 		return entity != null;
-	}
-
-	@Override
-	@SideOnly(Side.CLIENT)
-	public void renderSpell(@Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
-
 	}
 }

--- a/src/main/java/com/teamwizardry/wizardry/common/module/events/ModuleEventCollideEntity.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/events/ModuleEventCollideEntity.java
@@ -3,7 +3,6 @@ package com.teamwizardry.wizardry.common.module.events;
 import com.teamwizardry.wizardry.api.spell.SpellData;
 import com.teamwizardry.wizardry.api.spell.SpellRing;
 import com.teamwizardry.wizardry.api.spell.module.IModuleEvent;
-import com.teamwizardry.wizardry.api.spell.module.Module;
 import com.teamwizardry.wizardry.api.spell.module.ModuleEvent;
 import com.teamwizardry.wizardry.api.spell.module.RegisterModule;
 import net.minecraft.entity.Entity;

--- a/src/main/java/com/teamwizardry/wizardry/common/module/events/ModuleEventCollideEntity.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/events/ModuleEventCollideEntity.java
@@ -19,7 +19,7 @@ public class ModuleEventCollideEntity implements IModuleEvent {
 
 	@Nonnull
 	@Override
-	public String getID() {
+	public String getClassID() {
 		return "event_collide_entity";
 	}
 

--- a/src/main/java/com/teamwizardry/wizardry/common/module/modifiers/ModuleModifierException.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/modifiers/ModuleModifierException.java
@@ -1,6 +1,6 @@
 package com.teamwizardry.wizardry.common.module.modifiers;
 
-import com.teamwizardry.wizardry.api.spell.module.ModuleModifier;
+import com.teamwizardry.wizardry.api.spell.module.IModuleModifier;
 import com.teamwizardry.wizardry.api.spell.module.RegisterModule;
 
 import javax.annotation.Nonnull;
@@ -9,11 +9,12 @@ import javax.annotation.Nonnull;
  * Created by Demoniaque.
  */
 @RegisterModule
-public class ModuleModifierException extends ModuleModifier {
+public class ModuleModifierException implements IModuleModifier {
 
 	@Nonnull
 	@Override
 	public String getID() {
 		return "modifier_exception";
 	}
+
 }

--- a/src/main/java/com/teamwizardry/wizardry/common/module/modifiers/ModuleModifierException.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/modifiers/ModuleModifierException.java
@@ -13,7 +13,7 @@ public class ModuleModifierException implements IModuleModifier {
 
 	@Nonnull
 	@Override
-	public String getID() {
+	public String getClassID() {
 		return "modifier_exception";
 	}
 

--- a/src/main/java/com/teamwizardry/wizardry/common/module/modifiers/ModuleModifierIncreaseAOE.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/modifiers/ModuleModifierIncreaseAOE.java
@@ -13,7 +13,7 @@ public class ModuleModifierIncreaseAOE implements IModuleModifier {
 
 	@Nonnull
 	@Override
-	public String getID() {
+	public String getClassID() {
 		return "modifier_increase_aoe";
 	}
 }

--- a/src/main/java/com/teamwizardry/wizardry/common/module/modifiers/ModuleModifierIncreaseAOE.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/modifiers/ModuleModifierIncreaseAOE.java
@@ -1,6 +1,6 @@
 package com.teamwizardry.wizardry.common.module.modifiers;
 
-import com.teamwizardry.wizardry.api.spell.module.ModuleModifier;
+import com.teamwizardry.wizardry.api.spell.module.IModuleModifier;
 import com.teamwizardry.wizardry.api.spell.module.RegisterModule;
 
 import javax.annotation.Nonnull;
@@ -9,7 +9,7 @@ import javax.annotation.Nonnull;
  * Created by Demoniaque.
  */
 @RegisterModule
-public class ModuleModifierIncreaseAOE extends ModuleModifier {
+public class ModuleModifierIncreaseAOE implements IModuleModifier {
 
 	@Nonnull
 	@Override

--- a/src/main/java/com/teamwizardry/wizardry/common/module/modifiers/ModuleModifierIncreaseDuration.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/modifiers/ModuleModifierIncreaseDuration.java
@@ -1,6 +1,6 @@
 package com.teamwizardry.wizardry.common.module.modifiers;
 
-import com.teamwizardry.wizardry.api.spell.module.ModuleModifier;
+import com.teamwizardry.wizardry.api.spell.module.IModuleModifier;
 import com.teamwizardry.wizardry.api.spell.module.RegisterModule;
 
 import javax.annotation.Nonnull;
@@ -9,7 +9,7 @@ import javax.annotation.Nonnull;
  * Created by Demoniaque.
  */
 @RegisterModule
-public class ModuleModifierIncreaseDuration extends ModuleModifier {
+public class ModuleModifierIncreaseDuration implements IModuleModifier {
 
 	@Nonnull
 	@Override

--- a/src/main/java/com/teamwizardry/wizardry/common/module/modifiers/ModuleModifierIncreaseDuration.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/modifiers/ModuleModifierIncreaseDuration.java
@@ -13,7 +13,7 @@ public class ModuleModifierIncreaseDuration implements IModuleModifier {
 
 	@Nonnull
 	@Override
-	public String getID() {
+	public String getClassID() {
 		return "modifier_extend_time";
 	}
 

--- a/src/main/java/com/teamwizardry/wizardry/common/module/modifiers/ModuleModifierIncreasePotency.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/modifiers/ModuleModifierIncreasePotency.java
@@ -13,7 +13,7 @@ public class ModuleModifierIncreasePotency implements IModuleModifier {
 
 	@Nonnull
 	@Override
-	public String getID() {
+	public String getClassID() {
 		return "modifier_increase_potency";
 	}
 }

--- a/src/main/java/com/teamwizardry/wizardry/common/module/modifiers/ModuleModifierIncreasePotency.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/modifiers/ModuleModifierIncreasePotency.java
@@ -1,6 +1,6 @@
 package com.teamwizardry.wizardry.common.module.modifiers;
 
-import com.teamwizardry.wizardry.api.spell.module.ModuleModifier;
+import com.teamwizardry.wizardry.api.spell.module.IModuleModifier;
 import com.teamwizardry.wizardry.api.spell.module.RegisterModule;
 
 import javax.annotation.Nonnull;
@@ -9,7 +9,7 @@ import javax.annotation.Nonnull;
  * Created by Demoniaque.
  */
 @RegisterModule
-public class ModuleModifierIncreasePotency extends ModuleModifier {
+public class ModuleModifierIncreasePotency implements IModuleModifier {
 
 	@Nonnull
 	@Override

--- a/src/main/java/com/teamwizardry/wizardry/common/module/modifiers/ModuleModifierIncreaseRange.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/modifiers/ModuleModifierIncreaseRange.java
@@ -13,7 +13,7 @@ public class ModuleModifierIncreaseRange implements IModuleModifier {
 
 	@Nonnull
 	@Override
-	public String getID() {
+	public String getClassID() {
 		return "modifier_extend_range";
 	}
 }

--- a/src/main/java/com/teamwizardry/wizardry/common/module/modifiers/ModuleModifierIncreaseRange.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/modifiers/ModuleModifierIncreaseRange.java
@@ -1,6 +1,6 @@
 package com.teamwizardry.wizardry.common.module.modifiers;
 
-import com.teamwizardry.wizardry.api.spell.module.ModuleModifier;
+import com.teamwizardry.wizardry.api.spell.module.IModuleModifier;
 import com.teamwizardry.wizardry.api.spell.module.RegisterModule;
 
 import javax.annotation.Nonnull;
@@ -9,7 +9,7 @@ import javax.annotation.Nonnull;
  * Created by Demoniaque.
  */
 @RegisterModule
-public class ModuleModifierIncreaseRange extends ModuleModifier {
+public class ModuleModifierIncreaseRange implements IModuleModifier {
 
 	@Nonnull
 	@Override

--- a/src/main/java/com/teamwizardry/wizardry/common/module/modifiers/ModuleModifierIncreaseSpeed.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/modifiers/ModuleModifierIncreaseSpeed.java
@@ -1,6 +1,6 @@
 package com.teamwizardry.wizardry.common.module.modifiers;
 
-import com.teamwizardry.wizardry.api.spell.module.ModuleModifier;
+import com.teamwizardry.wizardry.api.spell.module.IModuleModifier;
 import com.teamwizardry.wizardry.api.spell.module.RegisterModule;
 
 import javax.annotation.Nonnull;
@@ -9,7 +9,7 @@ import javax.annotation.Nonnull;
  * Created by Demoniaque.
  */
 @RegisterModule
-public class ModuleModifierIncreaseSpeed extends ModuleModifier {
+public class ModuleModifierIncreaseSpeed implements IModuleModifier {
 
 	@Nonnull
 	@Override

--- a/src/main/java/com/teamwizardry/wizardry/common/module/modifiers/ModuleModifierIncreaseSpeed.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/modifiers/ModuleModifierIncreaseSpeed.java
@@ -13,7 +13,7 @@ public class ModuleModifierIncreaseSpeed implements IModuleModifier {
 
 	@Nonnull
 	@Override
-	public String getID() {
+	public String getClassID() {
 		return "modifier_increase_speed";
 	}
 }

--- a/src/main/java/com/teamwizardry/wizardry/common/module/shapes/ModuleShapeBeam.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/shapes/ModuleShapeBeam.java
@@ -6,7 +6,9 @@ import com.teamwizardry.wizardry.api.spell.IContinuousModule;
 import com.teamwizardry.wizardry.api.spell.SpellData;
 import com.teamwizardry.wizardry.api.spell.SpellRing;
 import com.teamwizardry.wizardry.api.spell.attribute.AttributeRegistry;
-import com.teamwizardry.wizardry.api.spell.module.ModuleModifier;
+import com.teamwizardry.wizardry.api.spell.module.IModuleModifier;
+import com.teamwizardry.wizardry.api.spell.module.IModuleShape;
+import com.teamwizardry.wizardry.api.spell.module.Module;
 import com.teamwizardry.wizardry.api.spell.module.ModuleShape;
 import com.teamwizardry.wizardry.api.spell.module.RegisterModule;
 import com.teamwizardry.wizardry.api.util.RandUtil;
@@ -40,7 +42,7 @@ import static com.teamwizardry.wizardry.api.spell.SpellData.DefaultKeys.LOOK;
  */
 @RegisterModule
 @Mod.EventBusSubscriber(modid = Wizardry.MODID)
-public class ModuleShapeBeam extends ModuleShape implements IContinuousModule {
+public class ModuleShapeBeam implements IModuleShape, IContinuousModule {
 
 	public static final String BEAM_OFFSET = "beam offset";
 	public static final String BEAM_CAST = "beam cast";
@@ -54,8 +56,8 @@ public class ModuleShapeBeam extends ModuleShape implements IContinuousModule {
 	}
 
 	@Override
-	public ModuleModifier[] applicableModifiers() {
-		return new ModuleModifier[]{new ModuleModifierIncreaseRange(), new ModuleModifierIncreasePotency()};
+	public IModuleModifier[] applicableModifiers() {
+		return new IModuleModifier[]{new ModuleModifierIncreaseRange(), new ModuleModifierIncreasePotency()};
 	}
 
 	@Override
@@ -72,7 +74,7 @@ public class ModuleShapeBeam extends ModuleShape implements IContinuousModule {
 	}
 
 	@Override
-	public boolean run(@Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public boolean run(ModuleShape instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		World world = spell.world;
 		Vec3d look = spell.getData(LOOK);
 		Vec3d position = spell.getOrigin();
@@ -98,7 +100,7 @@ public class ModuleShapeBeam extends ModuleShape implements IContinuousModule {
 				return false;
 			}
 
-			runRunOverrides(spell, spellRing);
+			instance.runRunOverrides(spell, spellRing);
 
 			RayTraceResult trace = new RayTrace(world, look, position, range)
 					.setEntityFilter(input -> input != caster)
@@ -112,7 +114,7 @@ public class ModuleShapeBeam extends ModuleShape implements IContinuousModule {
 				spellRing.getChildRing().runSpellRing(spell);
 
 			ticker.cast = true;
-			sendRenderPacket(spell, spellRing);
+			instance.sendRenderPacket(spell, spellRing);
 		}
 
 		ticker.ticks = beamOffset;
@@ -148,7 +150,7 @@ public class ModuleShapeBeam extends ModuleShape implements IContinuousModule {
 
 	@NotNull
 	@Override
-	public SpellData renderVisualization(@Nonnull SpellData data, @Nonnull SpellRing ring, @Nonnull SpellData previousData) {
+	public SpellData renderVisualization(ModuleShape instance, @Nonnull SpellData data, @Nonnull SpellRing ring, @Nonnull SpellData previousData) {
 		World world = data.world;
 		Vec3d look = data.getData(LOOK);
 		Vec3d position = data.getOrigin();
@@ -170,8 +172,8 @@ public class ModuleShapeBeam extends ModuleShape implements IContinuousModule {
 
 	@Override
 	@SideOnly(Side.CLIENT)
-	public void renderSpell(@Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
-		if (runRenderOverrides(spell, spellRing)) return;
+	public void renderSpell(ModuleShape instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+		if (instance.runRenderOverrides(spell, spellRing)) return;
 
 		World world = spell.world;
 		Vec3d look = spell.getData(LOOK);

--- a/src/main/java/com/teamwizardry/wizardry/common/module/shapes/ModuleShapeBeam.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/shapes/ModuleShapeBeam.java
@@ -8,8 +8,7 @@ import com.teamwizardry.wizardry.api.spell.SpellRing;
 import com.teamwizardry.wizardry.api.spell.attribute.AttributeRegistry;
 import com.teamwizardry.wizardry.api.spell.module.IModuleModifier;
 import com.teamwizardry.wizardry.api.spell.module.IModuleShape;
-import com.teamwizardry.wizardry.api.spell.module.Module;
-import com.teamwizardry.wizardry.api.spell.module.ModuleShape;
+import com.teamwizardry.wizardry.api.spell.module.ModuleInstanceShape;
 import com.teamwizardry.wizardry.api.spell.module.RegisterModule;
 import com.teamwizardry.wizardry.api.util.RandUtil;
 import com.teamwizardry.wizardry.api.util.RayTrace;
@@ -74,7 +73,7 @@ public class ModuleShapeBeam implements IModuleShape, IContinuousModule {
 	}
 
 	@Override
-	public boolean run(ModuleShape instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public boolean run(ModuleInstanceShape instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		World world = spell.world;
 		Vec3d look = spell.getData(LOOK);
 		Vec3d position = spell.getOrigin();
@@ -150,7 +149,7 @@ public class ModuleShapeBeam implements IModuleShape, IContinuousModule {
 
 	@NotNull
 	@Override
-	public SpellData renderVisualization(ModuleShape instance, @Nonnull SpellData data, @Nonnull SpellRing ring, @Nonnull SpellData previousData) {
+	public SpellData renderVisualization(ModuleInstanceShape instance, @Nonnull SpellData data, @Nonnull SpellRing ring, @Nonnull SpellData previousData) {
 		World world = data.world;
 		Vec3d look = data.getData(LOOK);
 		Vec3d position = data.getOrigin();
@@ -172,7 +171,7 @@ public class ModuleShapeBeam implements IModuleShape, IContinuousModule {
 
 	@Override
 	@SideOnly(Side.CLIENT)
-	public void renderSpell(ModuleShape instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public void renderSpell(ModuleInstanceShape instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		if (instance.runRenderOverrides(spell, spellRing)) return;
 
 		World world = spell.world;

--- a/src/main/java/com/teamwizardry/wizardry/common/module/shapes/ModuleShapeBeam.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/shapes/ModuleShapeBeam.java
@@ -51,7 +51,7 @@ public class ModuleShapeBeam implements IModuleShape, IContinuousModule {
 
 	@Nonnull
 	@Override
-	public String getID() {
+	public String getClassID() {
 		return "shape_beam";
 	}
 

--- a/src/main/java/com/teamwizardry/wizardry/common/module/shapes/ModuleShapeCone.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/shapes/ModuleShapeCone.java
@@ -10,7 +10,8 @@ import com.teamwizardry.wizardry.api.Constants;
 import com.teamwizardry.wizardry.api.spell.SpellData;
 import com.teamwizardry.wizardry.api.spell.SpellRing;
 import com.teamwizardry.wizardry.api.spell.attribute.AttributeRegistry;
-import com.teamwizardry.wizardry.api.spell.module.ModuleModifier;
+import com.teamwizardry.wizardry.api.spell.module.IModuleModifier;
+import com.teamwizardry.wizardry.api.spell.module.IModuleShape;
 import com.teamwizardry.wizardry.api.spell.module.ModuleShape;
 import com.teamwizardry.wizardry.api.spell.module.RegisterModule;
 import com.teamwizardry.wizardry.api.util.PosUtils;
@@ -36,7 +37,7 @@ import static com.teamwizardry.wizardry.api.spell.SpellData.DefaultKeys.*;
  * Created by Demoniaque.
  */
 @RegisterModule
-public class ModuleShapeCone extends ModuleShape {
+public class ModuleShapeCone implements IModuleShape {
 
 	@Nonnull
 	@Override
@@ -45,8 +46,8 @@ public class ModuleShapeCone extends ModuleShape {
 	}
 
 	@Override
-	public ModuleModifier[] applicableModifiers() {
-		return new ModuleModifier[]{new ModuleModifierIncreasePotency(), new ModuleModifierIncreaseRange()};
+	public IModuleModifier[] applicableModifiers() {
+		return new IModuleModifier[]{new ModuleModifierIncreasePotency(), new ModuleModifierIncreaseRange()};
 	}
 
 	@Override
@@ -55,7 +56,7 @@ public class ModuleShapeCone extends ModuleShape {
 	}
 
 	@Override
-	public boolean run(@Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public boolean run(ModuleShape instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		World world = spell.world;
 		float yaw = spell.getData(YAW, 0F);
 		float pitch = spell.getData(PITCH, 0F);
@@ -73,7 +74,7 @@ public class ModuleShapeCone extends ModuleShape {
 			
 			long seed = RandUtil.nextLong(100, 10000);
 			spell.addData(SEED, seed);
-			runRunOverrides(spell, spellRing);
+			instance.runRunOverrides(spell, spellRing);
 			
 			float angle = (float) range * 2;
 			float newPitch = pitch + RandUtil.nextFloat(-angle, angle);
@@ -91,7 +92,7 @@ public class ModuleShapeCone extends ModuleShape {
 			if (lookFallback != null) lookFallback.scale(range);
 			newSpell.processTrace(result, lookFallback);
 
-			sendRenderPacket(newSpell, spellRing);
+			instance.sendRenderPacket(newSpell, spellRing);
 
 			newSpell.addData(ORIGIN, result.hitVec);
 
@@ -105,8 +106,8 @@ public class ModuleShapeCone extends ModuleShape {
 
 	@Override
 	@SideOnly(Side.CLIENT)
-	public void renderSpell(@Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
-		if (runRenderOverrides(spell, spellRing)) return;
+	public void renderSpell(ModuleShape instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+		if (instance.runRenderOverrides(spell, spellRing)) return;
 
 		Vec3d target = spell.getTarget();
 

--- a/src/main/java/com/teamwizardry/wizardry/common/module/shapes/ModuleShapeCone.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/shapes/ModuleShapeCone.java
@@ -41,7 +41,7 @@ public class ModuleShapeCone implements IModuleShape {
 
 	@Nonnull
 	@Override
-	public String getID() {
+	public String getClassID() {
 		return "shape_cone";
 	}
 

--- a/src/main/java/com/teamwizardry/wizardry/common/module/shapes/ModuleShapeCone.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/shapes/ModuleShapeCone.java
@@ -12,7 +12,7 @@ import com.teamwizardry.wizardry.api.spell.SpellRing;
 import com.teamwizardry.wizardry.api.spell.attribute.AttributeRegistry;
 import com.teamwizardry.wizardry.api.spell.module.IModuleModifier;
 import com.teamwizardry.wizardry.api.spell.module.IModuleShape;
-import com.teamwizardry.wizardry.api.spell.module.ModuleShape;
+import com.teamwizardry.wizardry.api.spell.module.ModuleInstanceShape;
 import com.teamwizardry.wizardry.api.spell.module.RegisterModule;
 import com.teamwizardry.wizardry.api.util.PosUtils;
 import com.teamwizardry.wizardry.api.util.RandUtil;
@@ -56,7 +56,7 @@ public class ModuleShapeCone implements IModuleShape {
 	}
 
 	@Override
-	public boolean run(ModuleShape instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public boolean run(ModuleInstanceShape instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		World world = spell.world;
 		float yaw = spell.getData(YAW, 0F);
 		float pitch = spell.getData(PITCH, 0F);
@@ -106,7 +106,7 @@ public class ModuleShapeCone implements IModuleShape {
 
 	@Override
 	@SideOnly(Side.CLIENT)
-	public void renderSpell(ModuleShape instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public void renderSpell(ModuleInstanceShape instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		if (instance.runRenderOverrides(spell, spellRing)) return;
 
 		Vec3d target = spell.getTarget();

--- a/src/main/java/com/teamwizardry/wizardry/common/module/shapes/ModuleShapeProjectile.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/shapes/ModuleShapeProjectile.java
@@ -3,7 +3,8 @@ package com.teamwizardry.wizardry.common.module.shapes;
 import com.teamwizardry.wizardry.api.spell.SpellData;
 import com.teamwizardry.wizardry.api.spell.SpellRing;
 import com.teamwizardry.wizardry.api.spell.attribute.AttributeRegistry;
-import com.teamwizardry.wizardry.api.spell.module.ModuleModifier;
+import com.teamwizardry.wizardry.api.spell.module.IModuleModifier;
+import com.teamwizardry.wizardry.api.spell.module.IModuleShape;
 import com.teamwizardry.wizardry.api.spell.module.ModuleShape;
 import com.teamwizardry.wizardry.api.spell.module.RegisterModule;
 import com.teamwizardry.wizardry.api.util.RandUtil;
@@ -30,7 +31,7 @@ import static com.teamwizardry.wizardry.api.spell.SpellData.DefaultKeys.LOOK;
  * Created by Demoniaque.
  */
 @RegisterModule
-public class ModuleShapeProjectile extends ModuleShape {
+public class ModuleShapeProjectile implements IModuleShape {
 
 	@Nonnull
 	@Override
@@ -39,8 +40,8 @@ public class ModuleShapeProjectile extends ModuleShape {
 	}
 
 	@Override
-	public ModuleModifier[] applicableModifiers() {
-		return new ModuleModifier[]{new ModuleModifierIncreaseRange(), new ModuleModifierIncreaseSpeed()};
+	public IModuleModifier[] applicableModifiers() {
+		return new IModuleModifier[]{new ModuleModifierIncreaseRange(), new ModuleModifierIncreaseSpeed()};
 	}
 
 	@Override
@@ -49,7 +50,7 @@ public class ModuleShapeProjectile extends ModuleShape {
 	}
 
 	@Override
-	public boolean run(@Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public boolean run(ModuleShape instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		World world = spell.world;
 		if (world.isRemote) return true;
 
@@ -61,7 +62,7 @@ public class ModuleShapeProjectile extends ModuleShape {
 
 		if (!spellRing.taxCaster(spell, true)) return false;
 		
-		EntitySpellProjectile proj = new EntitySpellProjectile(world, spellRing, spell, (float) dist, (float) speed, (float) 0.1, !runRunOverrides(spell, spellRing));
+		EntitySpellProjectile proj = new EntitySpellProjectile(world, spellRing, spell, (float) dist, (float) speed, (float) 0.1, !instance.runRunOverrides(spell, spellRing));
 		proj.setPosition(origin.x, origin.y, origin.z);
 		proj.velocityChanged = true;
 
@@ -73,15 +74,15 @@ public class ModuleShapeProjectile extends ModuleShape {
 
 	@Override
 	@SideOnly(Side.CLIENT)
-	public void renderSpell(@Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public void renderSpell(ModuleShape instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		if (spellRing.isRunBeingOverriden()) {
-			runRenderOverrides(spell, spellRing);
+			instance.runRenderOverrides(spell, spellRing);
 		}
 	}
 
 	@NotNull
 	@Override
-	public SpellData renderVisualization(@Nonnull SpellData data, @Nonnull SpellRing ring, @Nonnull SpellData previousData) {
+	public SpellData renderVisualization(ModuleShape instance, @Nonnull SpellData data, @Nonnull SpellRing ring, @Nonnull SpellData previousData) {
 		Vec3d look = data.getData(LOOK);
 
 		Entity caster = data.getCaster();

--- a/src/main/java/com/teamwizardry/wizardry/common/module/shapes/ModuleShapeProjectile.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/shapes/ModuleShapeProjectile.java
@@ -5,7 +5,7 @@ import com.teamwizardry.wizardry.api.spell.SpellRing;
 import com.teamwizardry.wizardry.api.spell.attribute.AttributeRegistry;
 import com.teamwizardry.wizardry.api.spell.module.IModuleModifier;
 import com.teamwizardry.wizardry.api.spell.module.IModuleShape;
-import com.teamwizardry.wizardry.api.spell.module.ModuleShape;
+import com.teamwizardry.wizardry.api.spell.module.ModuleInstanceShape;
 import com.teamwizardry.wizardry.api.spell.module.RegisterModule;
 import com.teamwizardry.wizardry.api.util.RandUtil;
 import com.teamwizardry.wizardry.api.util.RayTrace;
@@ -50,7 +50,7 @@ public class ModuleShapeProjectile implements IModuleShape {
 	}
 
 	@Override
-	public boolean run(ModuleShape instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public boolean run(ModuleInstanceShape instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		World world = spell.world;
 		if (world.isRemote) return true;
 
@@ -74,7 +74,7 @@ public class ModuleShapeProjectile implements IModuleShape {
 
 	@Override
 	@SideOnly(Side.CLIENT)
-	public void renderSpell(ModuleShape instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public void renderSpell(ModuleInstanceShape instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		if (spellRing.isRunBeingOverriden()) {
 			instance.runRenderOverrides(spell, spellRing);
 		}
@@ -82,7 +82,7 @@ public class ModuleShapeProjectile implements IModuleShape {
 
 	@NotNull
 	@Override
-	public SpellData renderVisualization(ModuleShape instance, @Nonnull SpellData data, @Nonnull SpellRing ring, @Nonnull SpellData previousData) {
+	public SpellData renderVisualization(ModuleInstanceShape instance, @Nonnull SpellData data, @Nonnull SpellRing ring, @Nonnull SpellData previousData) {
 		Vec3d look = data.getData(LOOK);
 
 		Entity caster = data.getCaster();

--- a/src/main/java/com/teamwizardry/wizardry/common/module/shapes/ModuleShapeProjectile.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/shapes/ModuleShapeProjectile.java
@@ -35,7 +35,7 @@ public class ModuleShapeProjectile implements IModuleShape {
 
 	@Nonnull
 	@Override
-	public String getID() {
+	public String getClassID() {
 		return "shape_projectile";
 	}
 

--- a/src/main/java/com/teamwizardry/wizardry/common/module/shapes/ModuleShapeSelf.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/shapes/ModuleShapeSelf.java
@@ -9,6 +9,7 @@ import com.teamwizardry.wizardry.Wizardry;
 import com.teamwizardry.wizardry.api.Constants;
 import com.teamwizardry.wizardry.api.spell.SpellData;
 import com.teamwizardry.wizardry.api.spell.SpellRing;
+import com.teamwizardry.wizardry.api.spell.module.IModuleShape;
 import com.teamwizardry.wizardry.api.spell.module.ModuleShape;
 import com.teamwizardry.wizardry.api.spell.module.RegisterModule;
 import com.teamwizardry.wizardry.api.util.RandUtil;
@@ -27,7 +28,7 @@ import javax.annotation.Nonnull;
  * Created by Demoniaque.
  */
 @RegisterModule
-public class ModuleShapeSelf extends ModuleShape {
+public class ModuleShapeSelf implements IModuleShape {
 
 	@Nonnull
 	@Override
@@ -36,13 +37,13 @@ public class ModuleShapeSelf extends ModuleShape {
 	}
 
 	@Override
-	public boolean run(@Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public boolean run(ModuleShape instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		Entity caster = spell.getCaster();
 		if (caster == null) return false;
 
 		if (!spellRing.taxCaster(spell, true)) return false;
 		
-		runRunOverrides(spell, spellRing);
+		instance.runRunOverrides(spell, spellRing);
 		
 		spell.processEntity(caster, false);
 
@@ -51,8 +52,8 @@ public class ModuleShapeSelf extends ModuleShape {
 
 	@Override
 	@SideOnly(Side.CLIENT)
-	public void renderSpell(@Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
-		if (runRenderOverrides(spell, spellRing)) return;
+	public void renderSpell(ModuleShape instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+		if (instance.runRenderOverrides(spell, spellRing)) return;
 
 		Entity caster = spell.getCaster();
 		World world = spell.world;

--- a/src/main/java/com/teamwizardry/wizardry/common/module/shapes/ModuleShapeSelf.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/shapes/ModuleShapeSelf.java
@@ -32,7 +32,7 @@ public class ModuleShapeSelf implements IModuleShape {
 
 	@Nonnull
 	@Override
-	public String getID() {
+	public String getClassID() {
 		return "shape_self";
 	}
 

--- a/src/main/java/com/teamwizardry/wizardry/common/module/shapes/ModuleShapeSelf.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/shapes/ModuleShapeSelf.java
@@ -10,7 +10,7 @@ import com.teamwizardry.wizardry.api.Constants;
 import com.teamwizardry.wizardry.api.spell.SpellData;
 import com.teamwizardry.wizardry.api.spell.SpellRing;
 import com.teamwizardry.wizardry.api.spell.module.IModuleShape;
-import com.teamwizardry.wizardry.api.spell.module.ModuleShape;
+import com.teamwizardry.wizardry.api.spell.module.ModuleInstanceShape;
 import com.teamwizardry.wizardry.api.spell.module.RegisterModule;
 import com.teamwizardry.wizardry.api.util.RandUtil;
 import com.teamwizardry.wizardry.api.util.interp.InterpScale;
@@ -37,7 +37,7 @@ public class ModuleShapeSelf implements IModuleShape {
 	}
 
 	@Override
-	public boolean run(ModuleShape instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public boolean run(ModuleInstanceShape instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		Entity caster = spell.getCaster();
 		if (caster == null) return false;
 
@@ -52,7 +52,7 @@ public class ModuleShapeSelf implements IModuleShape {
 
 	@Override
 	@SideOnly(Side.CLIENT)
-	public void renderSpell(ModuleShape instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public void renderSpell(ModuleInstanceShape instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		if (instance.runRenderOverrides(spell, spellRing)) return;
 
 		Entity caster = spell.getCaster();

--- a/src/main/java/com/teamwizardry/wizardry/common/module/shapes/ModuleShapeTouch.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/shapes/ModuleShapeTouch.java
@@ -9,7 +9,7 @@ import com.teamwizardry.wizardry.api.Constants;
 import com.teamwizardry.wizardry.api.spell.SpellData;
 import com.teamwizardry.wizardry.api.spell.SpellRing;
 import com.teamwizardry.wizardry.api.spell.module.IModuleShape;
-import com.teamwizardry.wizardry.api.spell.module.ModuleShape;
+import com.teamwizardry.wizardry.api.spell.module.ModuleInstanceShape;
 import com.teamwizardry.wizardry.api.spell.module.RegisterModule;
 import com.teamwizardry.wizardry.api.util.RandUtil;
 import com.teamwizardry.wizardry.api.util.RayTrace;
@@ -42,7 +42,7 @@ public class ModuleShapeTouch implements IModuleShape {
 	}
 
 	@Override
-	public boolean run(ModuleShape instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public boolean run(ModuleInstanceShape instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		Vec3d look = spell.getData(LOOK);
 
 		Entity caster = spell.getCaster();
@@ -69,7 +69,7 @@ public class ModuleShapeTouch implements IModuleShape {
 
 	@NotNull
 	@Override
-	public SpellData renderVisualization(ModuleShape instance, @Nonnull SpellData data, @Nonnull SpellRing ring, @Nonnull SpellData previousData) {
+	public SpellData renderVisualization(ModuleInstanceShape instance, @Nonnull SpellData data, @Nonnull SpellRing ring, @Nonnull SpellData previousData) {
 		Vec3d look = data.getData(LOOK);
 
 		Entity caster = data.getCaster();
@@ -101,7 +101,7 @@ public class ModuleShapeTouch implements IModuleShape {
 
 	@Override
 	@SideOnly(Side.CLIENT)
-	public void renderSpell(ModuleShape instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public void renderSpell(ModuleInstanceShape instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		if (instance.runRenderOverrides(spell, spellRing)) return;
 
 		Entity targetEntity = spell.getVictim();

--- a/src/main/java/com/teamwizardry/wizardry/common/module/shapes/ModuleShapeTouch.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/shapes/ModuleShapeTouch.java
@@ -8,6 +8,7 @@ import com.teamwizardry.wizardry.Wizardry;
 import com.teamwizardry.wizardry.api.Constants;
 import com.teamwizardry.wizardry.api.spell.SpellData;
 import com.teamwizardry.wizardry.api.spell.SpellRing;
+import com.teamwizardry.wizardry.api.spell.module.IModuleShape;
 import com.teamwizardry.wizardry.api.spell.module.ModuleShape;
 import com.teamwizardry.wizardry.api.spell.module.RegisterModule;
 import com.teamwizardry.wizardry.api.util.RandUtil;
@@ -32,7 +33,7 @@ import static com.teamwizardry.wizardry.api.spell.SpellData.DefaultKeys.LOOK;
  * Created by Demoniaque.
  */
 @RegisterModule
-public class ModuleShapeTouch extends ModuleShape {
+public class ModuleShapeTouch implements IModuleShape {
 
 	@Nonnull
 	@Override
@@ -41,7 +42,7 @@ public class ModuleShapeTouch extends ModuleShape {
 	}
 
 	@Override
-	public boolean run(@Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public boolean run(ModuleShape instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		Vec3d look = spell.getData(LOOK);
 
 		Entity caster = spell.getCaster();
@@ -52,7 +53,7 @@ public class ModuleShapeTouch extends ModuleShape {
 		if (origin == null) return false;
 		if (!spellRing.taxCaster(spell, true)) return false;
 
-		runRunOverrides(spell, spellRing);
+		instance.runRunOverrides(spell, spellRing);
 		
 		RayTraceResult result = new RayTrace(
 				spell.world, look, origin,
@@ -68,7 +69,7 @@ public class ModuleShapeTouch extends ModuleShape {
 
 	@NotNull
 	@Override
-	public SpellData renderVisualization(@Nonnull SpellData data, @Nonnull SpellRing ring, @Nonnull SpellData previousData) {
+	public SpellData renderVisualization(ModuleShape instance, @Nonnull SpellData data, @Nonnull SpellRing ring, @Nonnull SpellData previousData) {
 		Vec3d look = data.getData(LOOK);
 
 		Entity caster = data.getCaster();
@@ -100,8 +101,8 @@ public class ModuleShapeTouch extends ModuleShape {
 
 	@Override
 	@SideOnly(Side.CLIENT)
-	public void renderSpell(@Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
-		if (runRenderOverrides(spell, spellRing)) return;
+	public void renderSpell(ModuleShape instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+		if (instance.runRenderOverrides(spell, spellRing)) return;
 
 		Entity targetEntity = spell.getVictim();
 

--- a/src/main/java/com/teamwizardry/wizardry/common/module/shapes/ModuleShapeTouch.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/shapes/ModuleShapeTouch.java
@@ -37,7 +37,7 @@ public class ModuleShapeTouch implements IModuleShape {
 
 	@Nonnull
 	@Override
-	public String getID() {
+	public String getClassID() {
 		return "shape_touch";
 	}
 

--- a/src/main/java/com/teamwizardry/wizardry/common/module/shapes/ModuleShapeZone.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/shapes/ModuleShapeZone.java
@@ -12,7 +12,8 @@ import com.teamwizardry.wizardry.api.spell.ILingeringModule;
 import com.teamwizardry.wizardry.api.spell.SpellData;
 import com.teamwizardry.wizardry.api.spell.SpellRing;
 import com.teamwizardry.wizardry.api.spell.attribute.AttributeRegistry;
-import com.teamwizardry.wizardry.api.spell.module.ModuleModifier;
+import com.teamwizardry.wizardry.api.spell.module.IModuleModifier;
+import com.teamwizardry.wizardry.api.spell.module.IModuleShape;
 import com.teamwizardry.wizardry.api.spell.module.ModuleShape;
 import com.teamwizardry.wizardry.api.spell.module.RegisterModule;
 import com.teamwizardry.wizardry.api.util.RandUtil;
@@ -42,7 +43,7 @@ import static com.teamwizardry.wizardry.api.spell.SpellData.DefaultKeys.*;
  * Created by Demoniaque.
  */
 @RegisterModule
-public class ModuleShapeZone extends ModuleShape implements ILingeringModule {
+public class ModuleShapeZone implements IModuleShape, ILingeringModule {
 
 	public static final String ZONE_OFFSET = "zone offset";
 	public static final String ZONE_CAST = "zone cast";
@@ -54,8 +55,8 @@ public class ModuleShapeZone extends ModuleShape implements ILingeringModule {
 	}
 
 	@Override
-	public ModuleModifier[] applicableModifiers() {
-		return new ModuleModifier[]{new ModuleModifierIncreaseAOE(), new ModuleModifierIncreasePotency(), new ModuleModifierIncreaseRange(), new ModuleModifierIncreaseDuration()};
+	public IModuleModifier[] applicableModifiers() {
+		return new IModuleModifier[]{new ModuleModifierIncreaseAOE(), new ModuleModifierIncreasePotency(), new ModuleModifierIncreaseRange(), new ModuleModifierIncreaseDuration()};
 	}
 
 	@Override
@@ -64,7 +65,7 @@ public class ModuleShapeZone extends ModuleShape implements ILingeringModule {
 	}
 
 	@Override
-	public boolean run(@Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public boolean run(ModuleShape instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		World world = spell.world;
 //		Vec3d position = spell.getData(ORIGIN);
 //		Entity caster = spell.getCaster();
@@ -93,7 +94,7 @@ public class ModuleShapeZone extends ModuleShape implements ILingeringModule {
 				return false;
 			}
 			
-			runRunOverrides(spell, spellRing);
+			instance.runRunOverrides(spell, spellRing);
 			
 			BlockPos target = new BlockPos(RandUtil.nextDouble(min.x, max.x), RandUtil.nextDouble(min.y, max.y), RandUtil.nextDouble(min.z, max.z));
 			List<Entity> entities = world.getEntitiesWithinAABBExcludingEntity(null, new AxisAlignedBB(target));
@@ -129,8 +130,8 @@ public class ModuleShapeZone extends ModuleShape implements ILingeringModule {
 
 	@Override
 	@SideOnly(Side.CLIENT)
-	public void renderSpell(@Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
-		if (runRenderOverrides(spell, spellRing)) return;
+	public void renderSpell(ModuleShape instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+		if (instance.runRenderOverrides(spell, spellRing)) return;
 
 		Vec3d target = spell.getTarget();
 

--- a/src/main/java/com/teamwizardry/wizardry/common/module/shapes/ModuleShapeZone.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/shapes/ModuleShapeZone.java
@@ -50,7 +50,7 @@ public class ModuleShapeZone implements IModuleShape, ILingeringModule {
 	
 	@Nonnull
 	@Override
-	public String getID() {
+	public String getClassID() {
 		return "shape_zone";
 	}
 

--- a/src/main/java/com/teamwizardry/wizardry/common/module/shapes/ModuleShapeZone.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/module/shapes/ModuleShapeZone.java
@@ -14,7 +14,7 @@ import com.teamwizardry.wizardry.api.spell.SpellRing;
 import com.teamwizardry.wizardry.api.spell.attribute.AttributeRegistry;
 import com.teamwizardry.wizardry.api.spell.module.IModuleModifier;
 import com.teamwizardry.wizardry.api.spell.module.IModuleShape;
-import com.teamwizardry.wizardry.api.spell.module.ModuleShape;
+import com.teamwizardry.wizardry.api.spell.module.ModuleInstanceShape;
 import com.teamwizardry.wizardry.api.spell.module.RegisterModule;
 import com.teamwizardry.wizardry.api.util.RandUtil;
 import com.teamwizardry.wizardry.api.util.interp.InterpScale;
@@ -65,7 +65,7 @@ public class ModuleShapeZone implements IModuleShape, ILingeringModule {
 	}
 
 	@Override
-	public boolean run(ModuleShape instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public boolean run(ModuleInstanceShape instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		World world = spell.world;
 //		Vec3d position = spell.getData(ORIGIN);
 //		Entity caster = spell.getCaster();
@@ -130,7 +130,7 @@ public class ModuleShapeZone implements IModuleShape, ILingeringModule {
 
 	@Override
 	@SideOnly(Side.CLIENT)
-	public void renderSpell(ModuleShape instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
+	public void renderSpell(ModuleInstanceShape instance, @Nonnull SpellData spell, @Nonnull SpellRing spellRing) {
 		if (instance.runRenderOverrides(spell, spellRing)) return;
 
 		Vec3d target = spell.getTarget();

--- a/src/main/java/com/teamwizardry/wizardry/common/network/PacketSendSpellToBook.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/network/PacketSendSpellToBook.java
@@ -5,7 +5,7 @@ import com.teamwizardry.librarianlib.features.network.PacketBase;
 import com.teamwizardry.librarianlib.features.saving.Save;
 import com.teamwizardry.wizardry.api.Constants;
 import com.teamwizardry.wizardry.api.spell.CommonWorktableModule;
-import com.teamwizardry.wizardry.api.spell.module.Module;
+import com.teamwizardry.wizardry.api.spell.module.ModuleInstance;
 import com.teamwizardry.wizardry.init.ModItems;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
@@ -35,13 +35,13 @@ public class PacketSendSpellToBook extends PacketBase {
 	public PacketSendSpellToBook() {
 	}
 
-	public PacketSendSpellToBook(UUID playerUUID, List<List<Module>> compiledSpell, Set<CommonWorktableModule> commonModules) {
+	public PacketSendSpellToBook(UUID playerUUID, List<List<ModuleInstance>> compiledSpell, Set<CommonWorktableModule> commonModules) {
 		this.playerUUID = playerUUID;
 		if (compiledSpell == null || commonModules == null) return;
 
 		NBTTagList compiledList = new NBTTagList();
-		for (List<Module> moduleList : compiledSpell) {
-			for (Module module : moduleList)
+		for (List<ModuleInstance> moduleList : compiledSpell) {
+			for (ModuleInstance module : moduleList)
 				compiledList.appendTag(module.serialize());
 			compiledList.appendTag(new NBTTagString());
 		}

--- a/src/main/java/com/teamwizardry/wizardry/common/network/PacketSyncModules.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/network/PacketSyncModules.java
@@ -2,7 +2,7 @@ package com.teamwizardry.wizardry.common.network;
 
 import com.teamwizardry.librarianlib.features.network.PacketBase;
 import com.teamwizardry.librarianlib.features.saving.Save;
-import com.teamwizardry.wizardry.api.spell.module.Module;
+import com.teamwizardry.wizardry.api.spell.module.ModuleInstance;
 import com.teamwizardry.wizardry.api.spell.module.ModuleRegistry;
 import net.minecraftforge.fml.common.network.simpleimpl.MessageContext;
 
@@ -15,12 +15,12 @@ import java.util.ArrayList;
 public class PacketSyncModules extends PacketBase {
 
 	@Save
-	public ArrayList<Module> modules;
+	public ArrayList<ModuleInstance> modules;
 
 	public PacketSyncModules() {
 	}
 
-	public PacketSyncModules(ArrayList<Module> modules) {
+	public PacketSyncModules(ArrayList<ModuleInstance> modules) {
 		this.modules = modules;
 	}
 

--- a/src/main/java/com/teamwizardry/wizardry/common/tile/TileLight.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/tile/TileLight.java
@@ -27,6 +27,16 @@ import java.awt.*;
  */
 @TileRegister(Wizardry.MODID + ":light")
 public class TileLight extends TileMod implements ITickable {
+	
+	Module module = null;
+	
+	public void setModule(Module module) {
+		this.module = module;	// The light color is inherited from this given module
+	}
+	
+	public Module getModule() {
+		return this.module;
+	}
 
 	@Override
 	public void update() {
@@ -35,7 +45,20 @@ public class TileLight extends TileMod implements ITickable {
 			@SideOnly(Side.CLIENT)
 			public void runIfClient() {
 				if (RandUtil.nextInt(4) == 0) {
-					Module module = ModuleRegistry.INSTANCE.getModule("effect_light");
+//					Module module = ModuleRegistry.INSTANCE.getModule("effect_light");
+					
+					Color primaryColor;
+					Color secondaryColor;
+					if( module != null ) {
+						primaryColor = module.getPrimaryColor();
+						secondaryColor = module.getSecondaryColor();
+					}
+					else {
+						// NOTE: Usually should never happen, if tile entity is initialized correctly in ModuleEffectLight.
+						primaryColor = new Color(0xAA00AA);	// Purple color.
+						secondaryColor = new Color(0x000000);
+					}
+					
 					ParticleBuilder glitter = new ParticleBuilder(30);
 					glitter.setRender(new ResourceLocation(Wizardry.MODID, Constants.MISC.SPARKLE_BLURRED));
 					glitter.setAlphaFunction(new InterpFloatInOut(0.3f, 0.3f));
@@ -48,9 +71,9 @@ public class TileLight extends TileMod implements ITickable {
 								RandUtil.nextDouble(-0.01, 0.01)));
 
 						if (RandUtil.nextBoolean()) {
-							build.setColorFunction(new InterpColorHSV(module.getPrimaryColor(), module.getSecondaryColor()));
+							build.setColorFunction(new InterpColorHSV(primaryColor, secondaryColor));
 						} else {
-							build.setColorFunction(new InterpColorHSV(module.getSecondaryColor(), module.getPrimaryColor()));
+							build.setColorFunction(new InterpColorHSV(secondaryColor, primaryColor));
 						}
 					});
 				}

--- a/src/main/java/com/teamwizardry/wizardry/common/tile/TileLight.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/tile/TileLight.java
@@ -10,8 +10,7 @@ import com.teamwizardry.librarianlib.features.particle.functions.InterpColorHSV;
 import com.teamwizardry.librarianlib.features.utilities.client.ClientRunnable;
 import com.teamwizardry.wizardry.Wizardry;
 import com.teamwizardry.wizardry.api.Constants;
-import com.teamwizardry.wizardry.api.spell.module.Module;
-import com.teamwizardry.wizardry.api.spell.module.ModuleRegistry;
+import com.teamwizardry.wizardry.api.spell.module.ModuleInstance;
 import com.teamwizardry.wizardry.api.util.RandUtil;
 import com.teamwizardry.wizardry.api.util.interp.InterpScale;
 import net.minecraft.util.ITickable;
@@ -28,13 +27,13 @@ import java.awt.*;
 @TileRegister(Wizardry.MODID + ":light")
 public class TileLight extends TileMod implements ITickable {
 	
-	Module module = null;
+	ModuleInstance module = null;
 	
-	public void setModule(Module module) {
+	public void setModule(ModuleInstance module) {
 		this.module = module;	// The light color is inherited from this given module
 	}
 	
-	public Module getModule() {
+	public ModuleInstance getModule() {
 		return this.module;
 	}
 
@@ -45,8 +44,6 @@ public class TileLight extends TileMod implements ITickable {
 			@SideOnly(Side.CLIENT)
 			public void runIfClient() {
 				if (RandUtil.nextInt(4) == 0) {
-//					Module module = ModuleRegistry.INSTANCE.getModule("effect_light");
-					
 					Color primaryColor;
 					Color secondaryColor;
 					if( module != null ) {

--- a/src/main/resources/assets/wizardry/modules/effect_anti_gravity_well.json
+++ b/src/main/resources/assets/wizardry/modules/effect_anti_gravity_well.json
@@ -1,4 +1,6 @@
 {
+  "name": "effect_anti_gravity_well",
+  "type": "effect_anti_gravity_well",
   "item": "wizardry:bomb",
   "meta": "1",
   "primary_color": "0015ff",

--- a/src/main/resources/assets/wizardry/modules/effect_backup.json
+++ b/src/main/resources/assets/wizardry/modules/effect_backup.json
@@ -1,4 +1,6 @@
 {
+  "name": "effect_backup",
+  "type": "effect_backup",
   "item": "minecraft:rotten_flesh",
   "primary_color": "381700",
   "secondary_color": "8e0000",

--- a/src/main/resources/assets/wizardry/modules/effect_break.json
+++ b/src/main/resources/assets/wizardry/modules/effect_break.json
@@ -1,4 +1,6 @@
 {
+  "name": "effect_break",
+  "type": "effect_break",
   "item": "minecraft:sand",
   "primary_color": "A52A2A",
   "secondary_color": "FFA7A7",

--- a/src/main/resources/assets/wizardry/modules/effect_burn.json
+++ b/src/main/resources/assets/wizardry/modules/effect_burn.json
@@ -1,4 +1,6 @@
 {
+  "name": "effect_burn",
+  "type": "effect_burn",
   "item": "minecraft:blaze_powder",
   "primary_color": "FF3C3C",
   "secondary_color": "A10000",

--- a/src/main/resources/assets/wizardry/modules/effect_crasher_fall.json
+++ b/src/main/resources/assets/wizardry/modules/effect_crasher_fall.json
@@ -1,4 +1,6 @@
 {
+  "name": "effect_crasher_fall",
+  "type": "effect_crasher_fall",
   "item": "minecraft:obsidian",
   "mana_drain": 200.0,
   "burnout_fill": 100.0,

--- a/src/main/resources/assets/wizardry/modules/effect_disarm.json
+++ b/src/main/resources/assets/wizardry/modules/effect_disarm.json
@@ -1,4 +1,6 @@
 {
+  "name": "effect_disarm",
+  "type": "effect_disarm",
   "item": "minecraft:blaze_rod",
   "primary_color": "FFFFFF",
   "secondary_color": "FF0000",

--- a/src/main/resources/assets/wizardry/modules/effect_frost.json
+++ b/src/main/resources/assets/wizardry/modules/effect_frost.json
@@ -1,4 +1,6 @@
 {
+  "name": "effect_frost",
+  "type": "effect_frost",
   "item": "minecraft:snowball",
   "primary_color": "FFFFFF",
   "secondary_color": "FFFFFF",

--- a/src/main/resources/assets/wizardry/modules/effect_gravity_well.json
+++ b/src/main/resources/assets/wizardry/modules/effect_gravity_well.json
@@ -1,4 +1,6 @@
 {
+  "name": "effect_gravity_well",
+  "type": "effect_gravity_well",
   "item": "wizardry:bomb",
   "meta": "0",
   "primary_color": "ff0000",

--- a/src/main/resources/assets/wizardry/modules/effect_leap.json
+++ b/src/main/resources/assets/wizardry/modules/effect_leap.json
@@ -1,4 +1,6 @@
 {
+  "name": "effect_leap",
+  "type": "effect_leap",
   "item": "minecraft:rabbit_foot",
   "primary_color": "FFFFFF",
   "secondary_color": "FFFFFF",

--- a/src/main/resources/assets/wizardry/modules/effect_leech.json
+++ b/src/main/resources/assets/wizardry/modules/effect_leech.json
@@ -1,4 +1,6 @@
 {
+  "name": "effect_leech",
+  "type": "effect_leech",
   "item": "minecraft:lead",
   "primary_color": "00ffff",
   "secondary_color": "00ff61",

--- a/src/main/resources/assets/wizardry/modules/effect_light.json
+++ b/src/main/resources/assets/wizardry/modules/effect_light.json
@@ -1,4 +1,6 @@
 {
+  "name": "effect_light",
+  "type": "effect_light",
   "item": "minecraft:glowstone",
   "primary_color": "00FFFF",
   "secondary_color": "FF0000",

--- a/src/main/resources/assets/wizardry/modules/effect_lightning.json
+++ b/src/main/resources/assets/wizardry/modules/effect_lightning.json
@@ -1,4 +1,6 @@
 {
+  "name": "effect_lightning",
+  "type": "effect_lightning",
   "item": "minecraft:ice",
   "mana_drain": 200.0,
   "burnout_fill": 100.0,

--- a/src/main/resources/assets/wizardry/modules/effect_low_gravity.json
+++ b/src/main/resources/assets/wizardry/modules/effect_low_gravity.json
@@ -1,4 +1,6 @@
 {
+  "name": "effect_low_gravity",
+  "type": "effect_low_gravity",
   "item": "minecraft:feather",
   "mana_drain": 200.0,
   "burnout_fill": 100.0,

--- a/src/main/resources/assets/wizardry/modules/effect_phase.json
+++ b/src/main/resources/assets/wizardry/modules/effect_phase.json
@@ -1,4 +1,6 @@
 {
+  "name": "effect_phase",
+  "type": "effect_phase",
   "item": "minecraft:ender_pearl",
   "primary_color": "800000",
   "secondary_color": "FF0000",

--- a/src/main/resources/assets/wizardry/modules/effect_place.json
+++ b/src/main/resources/assets/wizardry/modules/effect_place.json
@@ -1,4 +1,6 @@
 {
+  "name": "effect_place",
+  "type": "effect_place",
   "item": "minecraft:clay",
   "primary_color": "2EFFFF",
   "secondary_color": "F3FFFF",

--- a/src/main/resources/assets/wizardry/modules/effect_substitution.json
+++ b/src/main/resources/assets/wizardry/modules/effect_substitution.json
@@ -1,4 +1,6 @@
 {
+  "name": "effect_substitution",
+  "type": "effect_substitution",
   "item": "minecraft:ender_eye",
   "primary_color": "FF0000",
   "secondary_color": "00FFFF",

--- a/src/main/resources/assets/wizardry/modules/effect_telekinesis.json
+++ b/src/main/resources/assets/wizardry/modules/effect_telekinesis.json
@@ -1,4 +1,6 @@
 {
+  "name": "effect_telekinesis",
+  "type": "effect_telekinesis",
   "item": "minecraft:reeds",
   "primary_color": "FFFFFF",
   "secondary_color": "FFFFFF",

--- a/src/main/resources/assets/wizardry/modules/effect_thrive.json
+++ b/src/main/resources/assets/wizardry/modules/effect_thrive.json
@@ -1,4 +1,6 @@
 {
+  "name": "effect_thrive",
+  "type": "effect_thrive",
   "item": "minecraft:bone",
   "primary_color": "00FFFF",
   "secondary_color": "00FFFF",

--- a/src/main/resources/assets/wizardry/modules/effect_time_slow.json
+++ b/src/main/resources/assets/wizardry/modules/effect_time_slow.json
@@ -1,4 +1,6 @@
 {
+  "name": "effect_time_slow",
+  "type": "effect_time_slow",
   "item": "minecraft:red_flower",
   "primary_color": "8D0000",
   "secondary_color": "FFA5A5",

--- a/src/main/resources/assets/wizardry/modules/effect_vanish.json
+++ b/src/main/resources/assets/wizardry/modules/effect_vanish.json
@@ -1,4 +1,6 @@
 {
+  "name": "effect_vanish",
+  "type": "effect_vanish",
   "item": "minecraft:fermented_spider_eye",
   "primary_color": "FFFFFF",
   "secondary_color": "42D1D1",

--- a/src/main/resources/assets/wizardry/modules/effect_zoom.json
+++ b/src/main/resources/assets/wizardry/modules/effect_zoom.json
@@ -1,4 +1,6 @@
 {
+  "name": "effect_zoom",
+  "type": "effect_zoom",
   "item": "wizardry:fairy_wings",
   "primary_color": "f442ce",
   "secondary_color": "41d9f4",

--- a/src/main/resources/assets/wizardry/modules/event_collide_block.json
+++ b/src/main/resources/assets/wizardry/modules/event_collide_block.json
@@ -1,4 +1,6 @@
 {
+  "name": "event_collide_block",
+  "type": "event_collide_block",
   "item": "minecraft:coal",
   "mana": { "base": 10 },
   "burnout": { "base": 5 }

--- a/src/main/resources/assets/wizardry/modules/event_collide_entity.json
+++ b/src/main/resources/assets/wizardry/modules/event_collide_entity.json
@@ -1,4 +1,6 @@
 {
+  "name": "event_collide_entity",
+  "type": "event_collide_entity",
   "item": "minecraft:apple",
   "mana": { "base": 10 },
   "burnout": { "base": 5 }

--- a/src/main/resources/assets/wizardry/modules/modifier_exception.json
+++ b/src/main/resources/assets/wizardry/modules/modifier_exception.json
@@ -1,4 +1,6 @@
 {
+  "name": "modifier_exception",
+  "type": "modifier_exception",
   "item": "wizardry:syringe_blood",
   "modifiers": [
     {

--- a/src/main/resources/assets/wizardry/modules/modifier_extend_range.json
+++ b/src/main/resources/assets/wizardry/modules/modifier_extend_range.json
@@ -1,4 +1,6 @@
 {
+  "name": "modifier_extend_range",
+  "type": "modifier_extend_range",
   "item": "minecraft:dye",
   "item_meta": "4",
   "modifiers": [

--- a/src/main/resources/assets/wizardry/modules/modifier_extend_time.json
+++ b/src/main/resources/assets/wizardry/modules/modifier_extend_time.json
@@ -1,4 +1,6 @@
 {
+  "name": "modifier_extend_time",
+  "type": "modifier_extend_time",
   "item": "minecraft:gold_nugget",
   "modifiers": [
     {

--- a/src/main/resources/assets/wizardry/modules/modifier_increase_aoe.json
+++ b/src/main/resources/assets/wizardry/modules/modifier_increase_aoe.json
@@ -1,4 +1,6 @@
 {
+  "name": "modifier_increase_aoe",
+  "type": "modifier_increase_aoe",
   "item": "minecraft:emerald",
   "modifiers": [
     {

--- a/src/main/resources/assets/wizardry/modules/modifier_increase_potency.json
+++ b/src/main/resources/assets/wizardry/modules/modifier_increase_potency.json
@@ -1,4 +1,6 @@
 {
+  "name": "modifier_increase_potency",
+  "type": "modifier_increase_potency",
   "item": "minecraft:prismarine_crystals",
   "modifiers": [
     {

--- a/src/main/resources/assets/wizardry/modules/modifier_increase_speed.json
+++ b/src/main/resources/assets/wizardry/modules/modifier_increase_speed.json
@@ -1,4 +1,6 @@
 {
+  "name": "modifier_increase_speed",
+  "type": "modifier_increase_speed",
   "item": "minecraft:dragon_breath",
   "modifiers": [
     {

--- a/src/main/resources/assets/wizardry/modules/shape_beam.json
+++ b/src/main/resources/assets/wizardry/modules/shape_beam.json
@@ -1,4 +1,6 @@
 {
+  "name": "shape_beam",
+  "type": "shape_beam",
   "item": "wizardry:unicorn_horn",
   "mana": {
     "base": 10,

--- a/src/main/resources/assets/wizardry/modules/shape_cone.json
+++ b/src/main/resources/assets/wizardry/modules/shape_cone.json
@@ -1,4 +1,6 @@
 {
+  "name": "shape_cone",
+  "type": "shape_cone",
   "item": "minecraft:gunpowder",
   "mana": {
     "base": 40

--- a/src/main/resources/assets/wizardry/modules/shape_projectile.json
+++ b/src/main/resources/assets/wizardry/modules/shape_projectile.json
@@ -1,4 +1,6 @@
 {
+  "name": "shape_projectile",
+  "type": "shape_projectile",
   "item": "minecraft:nether_wart",
   "mana": {
     "base": 50

--- a/src/main/resources/assets/wizardry/modules/shape_self.json
+++ b/src/main/resources/assets/wizardry/modules/shape_self.json
@@ -1,4 +1,6 @@
 {
+  "name": "shape_self",
+  "type": "shape_self",
   "item": "minecraft:diamond",
   "mana": {
     "base": 30

--- a/src/main/resources/assets/wizardry/modules/shape_touch.json
+++ b/src/main/resources/assets/wizardry/modules/shape_touch.json
@@ -1,4 +1,6 @@
 {
+  "name": "shape_touch",
+  "type": "shape_touch",
   "item": "minecraft:beef",
   "mana": {
     "base": 30

--- a/src/main/resources/assets/wizardry/modules/shape_zone.json
+++ b/src/main/resources/assets/wizardry/modules/shape_zone.json
@@ -1,4 +1,6 @@
 {
+    "name": "shape_zone",
+    "type": "shape_zone",
 	"item": "minecraft:glass",
 	"mana": {
 		"base": 50


### PR DESCRIPTION
In this PR, spells are generated per config. Spell Modules can be reused for different spells now.
Three new attributes are added to a spell json:
- **name**: Unique name of the Spell. Is also used to lookup the language translation.
- **type**: ID of the corresponding Spell Module Class.
- **icon** (optional): Texture identifier (as resource name) of the icon as displayed in worktable GUI. If not provided, then the texture is derived from name.

Example of a spell json:
{
  **"name": "effect_anti_gravity_well",**
  **"type": "effect_anti_gravity_well",**
  **"icon": "wizardry:textures/gui/worktable/icons/effect_anti_gravity_well.png",**
  "item": "wizardry:bomb",
  "meta": "1",
  "primary_color": "0015ff",
  "secondary_color": "00ffe1",
  "mana": { "base": 0.5 },
  "burnout": { "base": 0.5 },
  "cooldown": { "base": 100 },
  "area": { "base": 3, "min": 3, "max": 16 },
  "potency": { "base": 10, "min": 10, "max": 50 },
  "duration": { "base": 10, "min": 10, "max": 64 }
}
