### PR TITLE
Bugfix: Access transformer is not contained in manifest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,8 @@ jar {
     manifest {
         attributes(
                 "FMLCorePluginContainsFMLMod": "true",
-                "FMLCorePlugin": "$core_plugin"
+                "FMLCorePlugin": "$core_plugin",
+                "FMLAT": 'wizardry_at.cfg'
         )
     }
 }


### PR DESCRIPTION
This bug happens for SpellRing cache implementation.