### PR TITLE
Fixed crash if no wizardry config folder exists

### DIFF
--- a/src/main/java/com/teamwizardry/wizardry/common/core/version/manifest/ManifestUpgrader.java
+++ b/src/main/java/com/teamwizardry/wizardry/common/core/version/manifest/ManifestUpgrader.java
@@ -54,12 +54,14 @@ public class ManifestUpgrader {
 			throw new IllegalStateException("Upgrade is already finalized");
 		
 		// rename category in manifest
-		HashMap<String, String> entry = manifestMap.get(oldName);
-		if( entry != null ) {
-			manifestMap.remove(oldName);
-			manifestMap.put(newName, entry);
-			
-			hasManifestChanged = true;
+		if( manifestMap != null ) {
+			HashMap<String, String> entry = manifestMap.get(oldName);
+			if( entry != null ) {
+				manifestMap.remove(oldName);
+				manifestMap.put(newName, entry);
+				
+				hasManifestChanged = true;
+			}
 		}
 		
 		// rename folder


### PR DESCRIPTION
The crash occurs in the manifest upgrader if no manifest.json file exists in the configuration.