### PR TITLE
Fixed a typo in the codex load message

### DIFF
--- a/src/main/resources/assets/wizardry/lang/en_us.lang
+++ b/src/main/resources/assets/wizardry/lang/en_us.lang
@@ -394,7 +394,7 @@ wizardry.pearlui.belt_full=Belt Full
 wizardry.pearlui.pop_pearls=Click any of the pearls to pop them out of the belt
 wizardry.pearlui.attach_pearls=Click here to attach all pearls in your inventory to this belt
 
-wizardry.table.spell_loaded=Spell loaded from condex.
+wizardry.table.spell_loaded=Spell loaded from codex.
 wizardry.table.paper_cleared=Paper cleared.
 wizardry.table.spell_saved=Spell saved to codex successfully! Open the book and check the new spell recipe tab.
 wizardry.table.no_codex_found=You do not have a codex in your inventory! Once you have one, you can save your spell into the book.


### PR DESCRIPTION
Fixed typo in lang file in spell table

Old:
Spell loaded from condex

New:
Spell loaded from codex

The change was from coNdex to codex