### PR TITLE
Fixed bug with shape modifiers not saving

### DIFF
--- a/src/main/java/com/teamwizardry/wizardry/client/gui/worktable/WorktableGui.java
+++ b/src/main/java/com/teamwizardry/wizardry/client/gui/worktable/WorktableGui.java
@@ -210,7 +210,20 @@ public class WorktableGui extends GuiBase {
 					CommonWorktableModule lastCommonModule = new CommonWorktableModule(head.hashCode(), head.getModule(), head.getPos(), null, new HashMap<>());
 					commonModules.add(lastCommonModule);
 					chain.add(head.getModule());
+					
+					// Add head modifiers
+					for (ModuleInstance module : ModuleRegistry.INSTANCE.getModules(ModuleType.MODIFIER)) {
+						if (!(module instanceof ModuleInstanceModifier)) continue;
+						if (!head.hasData(Integer.class, module.getNBTKey())) continue;
 
+						int count = head.getData(Integer.class, module.getNBTKey());
+						lastCommonModule.addModifier((ModuleInstanceModifier) module, count);
+
+						for (int i = 0; i < count; i++) {
+							chain.add(module);
+						}
+					}
+					
 					TableModule linksTo = head.getLinksTo();
 					while (linksTo != null) {
 						if (linksTo.isInvalid()) continue;


### PR DESCRIPTION
The modifiers on the shape of a spell (such as range on projectile) were not being saved to the book. The book would display the recipe as if the user had not selected any modifiers.